### PR TITLE
fix: clear clippy failures blocking CI

### DIFF
--- a/core/daemon/src/are/metrics.rs
+++ b/core/daemon/src/are/metrics.rs
@@ -192,15 +192,17 @@ impl RoutingMetrics {
         let should_update_first = self
             .first_comparison_at
             .as_ref()
-            .is_none_or(|current| parsed < *current);
+            .map(|current| parsed < *current)
+            .unwrap_or(true);
         if should_update_first {
-            self.first_comparison_at = Some(parsed.clone());
+            self.first_comparison_at = Some(parsed);
         }
 
         let should_update_last = self
             .last_comparison_at
             .as_ref()
-            .is_none_or(|current| parsed > *current);
+            .map(|current| parsed > *current)
+            .unwrap_or(true);
         if should_update_last {
             self.last_comparison_at = Some(parsed);
         }
@@ -266,10 +268,7 @@ fn window_elapsed_hours(
         return None;
     };
 
-    let elapsed = last
-        .clone()
-        .signed_duration_since(first.clone())
-        .num_hours();
+    let elapsed = (*last).signed_duration_since(*first).num_hours();
     Some(elapsed.max(0) as u64)
 }
 

--- a/core/daemon/src/are/resolver.rs
+++ b/core/daemon/src/are/resolver.rs
@@ -118,7 +118,7 @@ pub fn resolve(input: ResolveInput<'_>) -> RoutingDiagnostics {
         conflicts.extend(collect_conflicts(&tmux_candidates, best));
         return build_result(
             input,
-            &best,
+            best,
             signal_ages_ms,
             candidate_targets,
             conflicts,
@@ -203,7 +203,7 @@ pub fn resolve(input: ResolveInput<'_>) -> RoutingDiagnostics {
         conflicts.extend(collect_conflicts(&tmux_session_candidates, best));
         return build_result(
             input,
-            &best,
+            best,
             signal_ages_ms,
             candidate_targets,
             conflicts,
@@ -297,7 +297,7 @@ pub fn resolve(input: ResolveInput<'_>) -> RoutingDiagnostics {
         conflicts.extend(collect_conflicts(&shell_candidates, best));
         return build_result(
             input,
-            &best,
+            best,
             signal_ages_ms,
             candidate_targets,
             conflicts,
@@ -315,7 +315,7 @@ pub fn resolve(input: ResolveInput<'_>) -> RoutingDiagnostics {
         conflicts.extend(collect_conflicts(&stale_shell_candidates, best));
         return build_result(
             input,
-            &best,
+            best,
             signal_ages_ms,
             candidate_targets,
             conflicts,

--- a/core/daemon/src/are/state.rs
+++ b/core/daemon/src/are/state.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_TMUX_POLL_INTERVAL_MS: u64 = 1_000;
 #[derive(Debug, Clone)]
 pub struct RoutingFeatureFlags {
     pub dual_run: bool,
+    #[allow(dead_code)]
     pub emit_diagnostics: bool,
 }
 
@@ -67,9 +68,5 @@ impl RoutingState {
     pub fn cache_snapshot(&mut self, snapshot: RoutingSnapshot) {
         self.snapshots
             .insert(snapshot.workspace_id.clone(), snapshot);
-    }
-
-    pub fn snapshot_for_workspace(&self, workspace_id: &str) -> Option<&RoutingSnapshot> {
-        self.snapshots.get(workspace_id)
     }
 }

--- a/core/daemon/src/are/tmux_poller.rs
+++ b/core/daemon/src/are/tmux_poller.rs
@@ -7,6 +7,7 @@ const TMUX_FIELD_DELIMITER: &str = "__CAP_DELIM__";
 
 #[derive(Debug, Clone)]
 pub struct TmuxSnapshot {
+    #[allow(dead_code)]
     pub captured_at: DateTime<Utc>,
     pub clients: Vec<TmuxClientSignal>,
     pub sessions: Vec<TmuxSessionSignal>,

--- a/core/daemon/src/hem.rs
+++ b/core/daemon/src/hem.rs
@@ -10,17 +10,12 @@ use crate::reducer::{SessionRecord, SessionState};
 
 const DEFAULT_HEM_CONFIG_RELATIVE_PATH: &str = ".capacitor/daemon/hem-v2.toml";
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum HemMode {
+    #[default]
     Shadow,
     Primary,
-}
-
-impl Default for HemMode {
-    fn default() -> Self {
-        Self::Shadow
-    }
 }
 
 fn default_hem_engine_mode() -> HemMode {
@@ -69,17 +64,12 @@ pub struct HemCapabilitiesConfig {
     pub tool_use_id_consistency: String,
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum HemCapabilityDetectionStrategy {
+    #[default]
     RuntimeHandshake,
     ConfigOnly,
-}
-
-impl Default for HemCapabilityDetectionStrategy {
-    fn default() -> Self {
-        Self::RuntimeHandshake
-    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/core/daemon/src/state.rs
+++ b/core/daemon/src/state.rs
@@ -1572,10 +1572,10 @@ fn mismatch_severity_rank(category: &str) -> u8 {
     }
 }
 
-fn select_mismatches_for_persistence<'a>(
-    mismatches: &'a [HemShadowMismatch],
+fn select_mismatches_for_persistence(
+    mismatches: &[HemShadowMismatch],
     limit: usize,
-) -> Vec<&'a HemShadowMismatch> {
+) -> Vec<&HemShadowMismatch> {
     if limit == 0 || mismatches.is_empty() {
         return Vec::new();
     }

--- a/core/hud-hook/src/daemon_client.rs
+++ b/core/hud-hook/src/daemon_client.rs
@@ -84,6 +84,7 @@ pub fn send_handle_event(
     send_event_with_retry(build_envelope, "session event").is_ok()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn send_shell_cwd_event(
     pid: u32,
     cwd: &str,


### PR DESCRIPTION
## Root cause
`CI -> Test Rust -> cargo clippy` fails with `-D warnings -W dead_code` due to accumulated clippy violations in daemon/hook code (dead code, MSRV-incompatible helpers, needless borrows/lifetimes, derivable defaults).

## What this changes
- fix clippy/MSRV issues in ARE metrics (`is_none_or` -> `map(...).unwrap_or(true)`; remove clone-on-copy)
- remove needless borrows in resolver `build_result(...)` calls
- derive `Default` for HEM enums instead of manual impls
- elide needless explicit lifetimes in mismatch persistence helper
- mark intentionally retained but currently unread fields with targeted `#[allow(dead_code)]`
- allow `send_shell_cwd_event` argument count (`#[allow(clippy::too_many_arguments)]`)

## Validation
- `cargo clippy -- -D warnings -W dead_code`
- `cargo test`
