### PR TITLE
Harden request-changes checkpoint semantics

### DIFF
--- a/apps/swift/Sources/Capacitor/Views/Projects/ProjectRunVisualStateResolver.swift
+++ b/apps/swift/Sources/Capacitor/Views/Projects/ProjectRunVisualStateResolver.swift
@@ -81,7 +81,6 @@ enum ProjectRunVisualStateResolver {
             statusMessage: cleanedStatusMessage(run.statusMessage),
         )
         if run.status == "paused",
-           run.activeCheckpoint != nil,
            !SessionStaleness.isPausedCheckpointStale(
                updatedAt: run.updatedAt,
                now: now,
@@ -112,7 +111,6 @@ enum ProjectRunVisualStateResolver {
 
     private static func priority(for run: RuntimeRunState, now: Date) -> Int? {
         if run.status == "paused",
-           run.activeCheckpoint != nil,
            !SessionStaleness.isPausedCheckpointStale(
                updatedAt: run.updatedAt,
                now: now,

--- a/apps/swift/Tests/CapacitorTests/ProjectRunVisualStateResolverTests.swift
+++ b/apps/swift/Tests/CapacitorTests/ProjectRunVisualStateResolverTests.swift
@@ -32,6 +32,40 @@ final class ProjectRunVisualStateResolverTests: XCTestCase {
         XCTAssertEqual(resolution.visualState, .waiting(statusMessage: nil))
     }
 
+    func testPausedRunWithoutCheckpointSurfacesAsWaiting() throws {
+        let projectPath = "/tmp/core-project"
+        let now = try XCTUnwrap(parseISO8601Date("2026-03-26T10:06:10Z"))
+        let activeRun = makeRun(
+            id: "run-active",
+            projectPath: projectPath,
+            status: "active",
+            updatedAt: "2026-03-26T10:05:00Z",
+            createdAt: "2026-03-26T10:00:00Z",
+            checkpointID: nil,
+        )
+        let pausedRun = makeRun(
+            id: "run-paused-blocked",
+            projectPath: projectPath,
+            status: "paused",
+            updatedAt: "2026-03-26T10:06:00Z",
+            createdAt: "2026-03-26T10:01:00Z",
+            checkpointID: nil,
+            statusMessage: "Run blocked: gate rejected",
+        )
+
+        let resolution = ProjectRunVisualStateResolver.resolve(
+            projectPath: projectPath,
+            runsByID: runsByID([activeRun, pausedRun]),
+            now: now,
+        )
+
+        XCTAssertEqual(resolution.run, pausedRun)
+        XCTAssertEqual(
+            resolution.visualState,
+            .waiting(statusMessage: "Run blocked: gate rejected"),
+        )
+    }
+
     func testActiveRunWinsOverCreatedRun() throws {
         let projectPath = "/tmp/core-project"
         let now = try XCTUnwrap(parseISO8601Date("2026-03-26T10:05:40Z"))

--- a/core/capacitor-core/src/bin/method_runner.rs
+++ b/core/capacitor-core/src/bin/method_runner.rs
@@ -17,6 +17,7 @@ use capacitor_core::method_runner::resume::resume_run_with_reporter;
 use capacitor_core::method_runner::run_status_reporter::{
     NoopRunStatusReporter, RunStatusReporter, RuntimeRunStatusReporter,
 };
+use capacitor_core::method_runner::state::RunStatus;
 use capacitor_core::method_runner::worker_dispatch_adapter::CodexWorkerDispatcher;
 use capacitor_core::runtime::service::{RuntimeServiceEndpoint, RUNTIME_SERVICE_DEFAULT_PORT};
 
@@ -276,15 +277,33 @@ fn print_run_result(
     >,
 ) -> ExitCode {
     match result {
-        Ok(state) => {
-            println!("{label} complete: run_id={}", state.run_id);
-            println!("status: {:?}", state.status);
-            println!(
-                "phases: {}",
-                state.phases.keys().cloned().collect::<Vec<_>>().join(", ")
-            );
-            ExitCode::SUCCESS
-        }
+        Ok(state) => match state.status {
+            RunStatus::Completed => {
+                println!("{label} complete: run_id={}", state.run_id);
+                println!("status: {:?}", state.status);
+                println!(
+                    "phases: {}",
+                    state.phases.keys().cloned().collect::<Vec<_>>().join(", ")
+                );
+                ExitCode::SUCCESS
+            }
+            RunStatus::Blocked => {
+                println!("{label} blocked: run_id={}", state.run_id);
+                println!("status: {:?}", state.status);
+                println!(
+                    "phases: {}",
+                    state.phases.keys().cloned().collect::<Vec<_>>().join(", ")
+                );
+                ExitCode::SUCCESS
+            }
+            RunStatus::Created | RunStatus::Running | RunStatus::Failed => {
+                eprintln!(
+                    "{label} ended in unexpected status {:?}: run_id={}",
+                    state.status, state.run_id
+                );
+                ExitCode::FAILURE
+            }
+        },
         Err(e) => {
             eprintln!("error: {e}");
             ExitCode::FAILURE
@@ -558,6 +577,35 @@ Flags:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+
+    use capacitor_core::method_runner::state::{MethodRunState, RunStatus};
+
+    fn method_state(status: RunStatus) -> MethodRunState {
+        MethodRunState {
+            run_id: "run-test".to_string(),
+            status,
+            definition_frozen: true,
+            phases: BTreeMap::new(),
+            seq: 1,
+        }
+    }
+
+    #[test]
+    fn print_run_result_treats_blocked_as_successful_handoff() {
+        assert_eq!(
+            print_run_result("run", Ok(method_state(RunStatus::Blocked))),
+            ExitCode::SUCCESS
+        );
+    }
+
+    #[test]
+    fn print_run_result_rejects_unexpected_running_final_state() {
+        assert_eq!(
+            print_run_result("run", Ok(method_state(RunStatus::Running))),
+            ExitCode::FAILURE
+        );
+    }
 
     #[test]
     fn worker_cwd_prefers_bridge_project_path_over_current_dir_and_root() {

--- a/core/capacitor-core/src/core_query.rs
+++ b/core/capacitor-core/src/core_query.rs
@@ -157,7 +157,7 @@ impl CoreRuntime {
             }
         }
 
-        suggestions.sort_by(|a, b| b.1.cmp(&a.1));
+        suggestions.sort_by_key(|(_, task_count)| std::cmp::Reverse(*task_count));
         Ok(suggestions.into_iter().take(8).map(|(s, _)| s).collect())
     }
 

--- a/core/capacitor-core/src/lib.rs
+++ b/core/capacitor-core/src/lib.rs
@@ -302,7 +302,7 @@ impl CoreRuntime {
             }
         }
 
-        plugins.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        plugins.sort_by_key(|plugin| plugin.name.to_lowercase());
         Ok(plugins)
     }
 

--- a/core/capacitor-core/src/method_runner/executor.rs
+++ b/core/capacitor-core/src/method_runner/executor.rs
@@ -596,7 +596,11 @@ fn emit_and_enforce_gate(
         env.payload = serde_json::json!({ "reason": reason });
         append_event(ctx.events_path, &mut env, &mut *ctx.current_seq)?;
     }
-    report_status_kind(ctx.reporter, RunStatusEventKind::Fail);
+    report_status_message(
+        ctx.reporter,
+        RunStatusEventKind::Pause,
+        format!("Run blocked: {reason}"),
+    );
 
     Err(RunError::PhaseGateBlocked {
         phase_id: phase.id.clone(),

--- a/core/capacitor-core/src/method_runner/executor.rs
+++ b/core/capacitor-core/src/method_runner/executor.rs
@@ -64,13 +64,6 @@ pub enum RunError {
 
     #[error("step '{step_id}' blocked: {reason}")]
     StepBlocked { step_id: String, reason: String },
-
-    #[error("phase '{phase_id}' blocked by gate '{gate_id}': {reason}")]
-    PhaseGateBlocked {
-        phase_id: String,
-        gate_id: String,
-        reason: String,
-    },
 }
 
 include!("executor_gate_support.rs");
@@ -382,7 +375,9 @@ fn execute_all_phases(ctx: &mut ExecutionContext<'_>) -> Result<Option<MethodRun
 
         // Evaluate phase gate (if present) after all steps complete
         if let Some(ref gate) = phase.gate {
-            emit_and_enforce_gate(ctx, phase, gate)?;
+            if let Some(early_state) = emit_and_enforce_gate(ctx, phase, gate)? {
+                return Ok(Some(early_state));
+            }
         }
 
         // PhaseCompleted
@@ -557,7 +552,7 @@ fn emit_and_enforce_gate(
     ctx: &mut ExecutionContext<'_>,
     phase: &NormalizedPhase,
     gate: &NormalizedGate,
-) -> Result<(), RunError> {
+) -> Result<Option<MethodRunState>, RunError> {
     let current_events = crate::method_runner::events::recover_events(ctx.events_path)?;
     let current_state = project(&current_events)?;
 
@@ -585,7 +580,7 @@ fn emit_and_enforce_gate(
     }
 
     if outcome == GateOutcome::Approved {
-        return Ok(());
+        return Ok(None);
     }
 
     let reason = gate_outcome_reason(&outcome);
@@ -596,17 +591,23 @@ fn emit_and_enforce_gate(
         env.payload = serde_json::json!({ "reason": reason });
         append_event(ctx.events_path, &mut env, &mut *ctx.current_seq)?;
     }
+
+    {
+        let summary = build_run_summary(ctx.events_path, ctx.normalized, ctx.run_start)?;
+        let mut env = make_envelope(ctx.run_id, MethodEventKind::RunBlocked);
+        env.payload = summary;
+        append_event(ctx.events_path, &mut env, &mut *ctx.current_seq)?;
+    }
     report_status_message(
         ctx.reporter,
         RunStatusEventKind::Pause,
         format!("Run blocked: {reason}"),
     );
 
-    Err(RunError::PhaseGateBlocked {
-        phase_id: phase.id.clone(),
-        gate_id: gate.id.clone(),
-        reason,
-    })
+    let events = crate::method_runner::events::recover_events(ctx.events_path)?;
+    let state = project(&events)?;
+    write_state_atomic(&ctx.paths.state_json(), &state).map_err(RunError::IoError)?;
+    Ok(Some(state))
 }
 
 /// Public wrapper for `execute_step` used by the resume module.

--- a/core/capacitor-core/src/method_runner/resume.rs
+++ b/core/capacitor-core/src/method_runner/resume.rs
@@ -308,7 +308,7 @@ pub fn resume_run_with_reporter(
         std::time::Duration::from_secs(10),
     )?;
 
-    resume_phase_loop(
+    if let Some(early_state) = resume_phase_loop(
         &paths,
         &events_path,
         &run_id,
@@ -320,7 +320,9 @@ pub fn resume_run_with_reporter(
         dispatcher,
         interactive_io,
         reporter,
-    )?;
+    )? {
+        return Ok(early_state);
+    }
 
     resolve_resume_outputs(
         &paths,
@@ -400,10 +402,18 @@ fn ensure_run_running(
     current_seq: &mut u64,
     reporter: &dyn RunStatusReporter,
 ) -> Result<(), RunError> {
-    if state.status == RunStatus::Created || state.status == RunStatus::Blocked {
-        let mut env = make_envelope(&state.run_id, MethodEventKind::RunStarted);
-        append_event(events_path, &mut env, current_seq)?;
-        report_status_message(reporter, RunStatusEventKind::Start, "Run started");
+    match state.status {
+        RunStatus::Created => {
+            let mut env = make_envelope(&state.run_id, MethodEventKind::RunStarted);
+            append_event(events_path, &mut env, current_seq)?;
+            report_status_message(reporter, RunStatusEventKind::Start, "Run started");
+        }
+        RunStatus::Blocked => {
+            let mut env = make_envelope(&state.run_id, MethodEventKind::RunStarted);
+            append_event(events_path, &mut env, current_seq)?;
+            report_status_message(reporter, RunStatusEventKind::Resume, "Run resumed");
+        }
+        _ => {}
     }
     Ok(())
 }
@@ -443,7 +453,7 @@ fn resume_phase_loop(
     dispatcher: &dyn crate::method_runner::adapters::WorkerDispatcher,
     interactive_io: &dyn crate::method_runner::adapters::InteractiveIO,
     reporter: &dyn RunStatusReporter,
-) -> Result<(), RunError> {
+) -> Result<Option<MethodRunState>, RunError> {
     for (pi, phase_def) in definition.method.phases.iter().enumerate() {
         if pi < phase_idx {
             continue;
@@ -463,14 +473,14 @@ fn resume_phase_loop(
             continue;
         }
 
-        if phase_status == PhaseStatus::Pending {
+        if phase_status == PhaseStatus::Pending || phase_status == PhaseStatus::Blocked {
             let mut env = make_envelope(run_id, MethodEventKind::PhaseStarted);
             env.phase_id = Some(phase_def.id.clone());
             append_event(events_path, &mut env, current_seq)?;
         }
         if suppress_phase_started_heartbeat {
             suppress_phase_started_heartbeat = false;
-        } else if phase_status == PhaseStatus::Pending {
+        } else if phase_status == PhaseStatus::Pending || phase_status == PhaseStatus::Blocked {
             report_status_message(
                 reporter,
                 RunStatusEventKind::Heartbeat,
@@ -491,7 +501,7 @@ fn resume_phase_loop(
         )?;
 
         if let Some(ref gate) = phase_def.gate {
-            resume_evaluate_gate(
+            if let Some(early_state) = resume_evaluate_gate(
                 paths,
                 events_path,
                 run_id,
@@ -500,7 +510,9 @@ fn resume_phase_loop(
                 gate,
                 interactive_io,
                 reporter,
-            )?;
+            )? {
+                return Ok(Some(early_state));
+            }
         }
 
         // PhaseCompleted
@@ -519,7 +531,7 @@ fn resume_phase_loop(
             suppress_phase_started_heartbeat = true;
         }
     }
-    Ok(())
+    Ok(None)
 }
 
 /// Execute non-terminal steps within a single resume phase.
@@ -585,7 +597,7 @@ fn resume_evaluate_gate(
     gate: &crate::method_runner::definition::NormalizedGate,
     interactive_io: &dyn crate::method_runner::adapters::InteractiveIO,
     reporter: &dyn RunStatusReporter,
-) -> Result<(), RunError> {
+) -> Result<Option<MethodRunState>, RunError> {
     let current_events = recover_events(events_path)?;
     let current_state = crate::method_runner::state::project(&current_events)?;
     *current_seq = current_state.seq;
@@ -620,7 +632,7 @@ fn resume_evaluate_gate(
     }
 
     match outcome {
-        crate::method_runner::executor::GateOutcome::Approved => Ok(()),
+        crate::method_runner::executor::GateOutcome::Approved => Ok(None),
         other => {
             let reason = match &other {
                 crate::method_runner::executor::GateOutcome::Rejected => {
@@ -643,16 +655,19 @@ fn resume_evaluate_gate(
             env.payload = serde_json::json!({ "reason": reason });
             append_event(events_path, &mut env, current_seq)?;
 
+            let mut env = make_envelope(run_id, MethodEventKind::RunBlocked);
+            env.payload = serde_json::json!({ "reason": reason });
+            append_event(events_path, &mut env, current_seq)?;
+
             report_status_message(
                 reporter,
                 RunStatusEventKind::Pause,
                 format!("Run blocked: {reason}"),
             );
-            Err(RunError::PhaseGateBlocked {
-                phase_id: phase_def.id.clone(),
-                gate_id: gate.id.clone(),
-                reason,
-            })
+            let final_state = project_resume_state(events_path)?;
+            crate::method_runner::state::write_state_atomic(&paths.state_json(), &final_state)
+                .map_err(RunError::IoError)?;
+            Ok(Some(final_state))
         }
     }
 }

--- a/core/capacitor-core/src/method_runner/resume.rs
+++ b/core/capacitor-core/src/method_runner/resume.rs
@@ -643,7 +643,11 @@ fn resume_evaluate_gate(
             env.payload = serde_json::json!({ "reason": reason });
             append_event(events_path, &mut env, current_seq)?;
 
-            report_status_kind(reporter, RunStatusEventKind::Fail);
+            report_status_message(
+                reporter,
+                RunStatusEventKind::Pause,
+                format!("Run blocked: {reason}"),
+            );
             Err(RunError::PhaseGateBlocked {
                 phase_id: phase_def.id.clone(),
                 gate_id: gate.id.clone(),

--- a/core/capacitor-core/src/method_runner/run_status_reporter.rs
+++ b/core/capacitor-core/src/method_runner/run_status_reporter.rs
@@ -16,6 +16,7 @@ pub enum RunStatusEventKind {
     Start,
     Heartbeat,
     AdvancePhase,
+    Pause,
     Complete,
     Fail,
 }
@@ -26,6 +27,7 @@ impl From<RunStatusEventKind> for RunMutationKind {
             RunStatusEventKind::Start => Self::Start,
             RunStatusEventKind::Heartbeat => Self::Heartbeat,
             RunStatusEventKind::AdvancePhase => Self::AdvancePhase,
+            RunStatusEventKind::Pause => Self::Pause,
             RunStatusEventKind::Complete => Self::Complete,
             RunStatusEventKind::Fail => Self::Fail,
         }

--- a/core/capacitor-core/src/method_runner/run_status_reporter.rs
+++ b/core/capacitor-core/src/method_runner/run_status_reporter.rs
@@ -17,6 +17,7 @@ pub enum RunStatusEventKind {
     Heartbeat,
     AdvancePhase,
     Pause,
+    Resume,
     Complete,
     Fail,
 }
@@ -28,6 +29,7 @@ impl From<RunStatusEventKind> for RunMutationKind {
             RunStatusEventKind::Heartbeat => Self::Heartbeat,
             RunStatusEventKind::AdvancePhase => Self::AdvancePhase,
             RunStatusEventKind::Pause => Self::Pause,
+            RunStatusEventKind::Resume => Self::Resume,
             RunStatusEventKind::Complete => Self::Complete,
             RunStatusEventKind::Fail => Self::Fail,
         }

--- a/core/capacitor-core/src/reduce/mod.rs
+++ b/core/capacitor-core/src/reduce/mod.rs
@@ -311,7 +311,7 @@ impl ReducerState {
         });
 
         let mut shells = cleaned_shells.values().cloned().collect::<Vec<_>>();
-        shells.sort_by(|left, right| left.pid.cmp(&right.pid));
+        shells.sort_by_key(|shell| shell.pid);
         let shell_count = shells.len() as u64;
 
         let routing = if cleaned_shells.len() == self.shells.len() {

--- a/core/capacitor-core/src/reduce/run_reducer.rs
+++ b/core/capacitor-core/src/reduce/run_reducer.rs
@@ -47,16 +47,20 @@ pub(crate) fn apply_run_mutation(
         RunMutationKind::CaptureComplete => handle_capture_complete(runs, &key, &command),
         RunMutationKind::AttachSession => handle_attach_session(runs, &key, &command),
         RunMutationKind::DetachSession => handle_detach_session(runs, &key),
-        RunMutationKind::Pause => handle_status_transition(runs, &key, RunStatus::Paused, "pause"),
+        RunMutationKind::Pause => {
+            handle_status_transition(runs, &key, RunStatus::Paused, &command, "pause")
+        }
         RunMutationKind::Resume => {
-            handle_status_transition(runs, &key, RunStatus::Active, "resume")
+            handle_status_transition(runs, &key, RunStatus::Active, &command, "resume")
         }
         RunMutationKind::Complete => {
-            handle_status_transition(runs, &key, RunStatus::Completed, "complete")
+            handle_status_transition(runs, &key, RunStatus::Completed, &command, "complete")
         }
-        RunMutationKind::Fail => handle_status_transition(runs, &key, RunStatus::Failed, "fail"),
+        RunMutationKind::Fail => {
+            handle_status_transition(runs, &key, RunStatus::Failed, &command, "fail")
+        }
         RunMutationKind::Cancel => {
-            handle_status_transition(runs, &key, RunStatus::Cancelled, "cancel")
+            handle_status_transition(runs, &key, RunStatus::Cancelled, &command, "cancel")
         }
     }
 }
@@ -208,6 +212,10 @@ fn handle_advance_phase(runs: &mut BTreeMap<String, RunState>, key: &str) -> Mut
 
     if run.active_checkpoint.is_some() {
         return reject("active checkpoint must be decided before advancing");
+    }
+
+    if run.status != RunStatus::Active {
+        return reject("run is not active");
     }
 
     let idx = run.current_phase_index as usize;
@@ -414,13 +422,17 @@ fn handle_submit_decision(
     checkpoint.status = CheckpointStatus::Decided;
     checkpoint.decided_at = Some(now.clone());
 
-    // Archive checkpoint and resume run.
+    // Archive checkpoint and advance the run according to the decision.
     let decided_checkpoint = run.active_checkpoint.take();
     if let Some(checkpoint) = decided_checkpoint {
         archive_decided_checkpoint(run, checkpoint);
     }
 
-    run.status = RunStatus::Active;
+    run.status = if action == "request_changes" {
+        RunStatus::Paused
+    } else {
+        RunStatus::Active
+    };
     run.updated_at = now;
     ok(&format!("decision recorded: {action}"))
 }
@@ -536,6 +548,7 @@ fn handle_status_transition(
     runs: &mut BTreeMap<String, RunState>,
     key: &str,
     target: RunStatus,
+    command: &MutateRunCommand,
     label: &str,
 ) -> MutationOutcome {
     let run = match runs.get_mut(key) {
@@ -553,6 +566,9 @@ fn handle_status_transition(
     }
 
     run.status = target;
+    if let Some(msg) = normalized_optional_text(command.status_message.as_deref()) {
+        run.status_message = Some(msg);
+    }
     run.updated_at = now_rfc3339();
     ok(&format!("run {label}"))
 }

--- a/core/capacitor-core/src/reduce/run_reducer/tests/lifecycle.rs
+++ b/core/capacitor-core/src/reduce/run_reducer/tests/lifecycle.rs
@@ -123,6 +123,51 @@ fn submit_decision_resumes_run() {
 }
 
 #[test]
+fn submit_request_changes_archives_checkpoint_and_keeps_run_paused() {
+    let mut runs = empty_runs();
+    apply_run_mutation(
+        &mut runs,
+        create_command("run-request-changes", "execution_only"),
+    );
+
+    let mut cmd = base_cmd("run-request-changes");
+    cmd.session_id = Some("s1".to_string());
+    mutate(&mut runs, cmd, RunMutationKind::AttachSession);
+
+    let mut cmd = base_cmd("run-request-changes");
+    cmd.checkpoint_kind = Some(CheckpointKind::ImplementationMilestone);
+    cmd.checkpoint_title = Some("M1".to_string());
+    mutate(&mut runs, cmd, RunMutationKind::EmitCheckpoint);
+
+    let mut cmd = base_cmd("run-request-changes");
+    cmd.checkpoint_id = Some(active_checkpoint_id(&runs, "run-request-changes"));
+    cmd.decision_action = Some("request_changes".to_string());
+    cmd.decision_note = Some("Fix the failing checks".to_string());
+    let result = mutate(&mut runs, cmd, RunMutationKind::SubmitDecision);
+    assert!(result.ok, "{}", result.message);
+
+    let run = runs.values().next().unwrap();
+    assert_eq!(run.status, RunStatus::Paused);
+    assert!(run.active_checkpoint.is_none());
+    assert_eq!(run.past_checkpoints.len(), 1);
+    let decided = &run.past_checkpoints[0];
+    assert_eq!(
+        decided
+            .decision
+            .as_ref()
+            .map(|decision| decision.action.as_str()),
+        Some("request_changes")
+    );
+    assert_eq!(
+        decided
+            .decision
+            .as_ref()
+            .and_then(|decision| decision.note.as_deref()),
+        Some("Fix the failing checks")
+    );
+}
+
+#[test]
 fn submit_decision_normalizes_bridge_aliases_to_runtime_actions() {
     for (input, canonical) in [
         ("approved", "approve"),
@@ -217,6 +262,38 @@ fn advance_phase_works() {
     assert_eq!(run.current_phase_index, 1);
     assert_eq!(run.phases[0].status, PhaseStatus::Completed);
     assert_eq!(run.phases[1].status, PhaseStatus::Active);
+}
+
+#[test]
+fn advance_phase_rejects_paused_run_without_active_checkpoint() {
+    let mut runs = empty_runs();
+    apply_run_mutation(
+        &mut runs,
+        create_command("run-paused-advance", "shape_and_execute"),
+    );
+
+    let mut cmd = base_cmd("run-paused-advance");
+    cmd.session_id = Some("s1".to_string());
+    mutate(&mut runs, cmd, RunMutationKind::AttachSession);
+
+    let pause_result = mutate(
+        &mut runs,
+        base_cmd("run-paused-advance"),
+        RunMutationKind::Pause,
+    );
+    assert!(pause_result.ok, "{}", pause_result.message);
+
+    let advance_result = mutate(
+        &mut runs,
+        base_cmd("run-paused-advance"),
+        RunMutationKind::AdvancePhase,
+    );
+    assert!(!advance_result.ok);
+    assert!(advance_result.message.contains("run is not active"));
+
+    let run = runs.values().next().unwrap();
+    assert_eq!(run.status, RunStatus::Paused);
+    assert_eq!(run.current_phase_index, 0);
 }
 
 #[test]

--- a/core/capacitor-core/src/reduce/run_reducer/tests/lifecycle.rs
+++ b/core/capacitor-core/src/reduce/run_reducer/tests/lifecycle.rs
@@ -297,6 +297,60 @@ fn advance_phase_rejects_paused_run_without_active_checkpoint() {
 }
 
 #[test]
+fn request_changes_pause_requires_resume_before_phase_advance() {
+    let mut runs = empty_runs();
+    apply_run_mutation(
+        &mut runs,
+        create_command("run-request-changes-resume", "shape_and_execute"),
+    );
+
+    let mut cmd = base_cmd("run-request-changes-resume");
+    cmd.session_id = Some("s1".to_string());
+    mutate(&mut runs, cmd, RunMutationKind::AttachSession);
+
+    let mut cmd = base_cmd("run-request-changes-resume");
+    cmd.checkpoint_kind = Some(CheckpointKind::Proposal);
+    cmd.checkpoint_title = Some("Proposal".to_string());
+    mutate(&mut runs, cmd, RunMutationKind::EmitCheckpoint);
+
+    let mut cmd = base_cmd("run-request-changes-resume");
+    cmd.checkpoint_id = Some(active_checkpoint_id(&runs, "run-request-changes-resume"));
+    cmd.decision_action = Some("request_changes".to_string());
+    let decision_result = mutate(&mut runs, cmd, RunMutationKind::SubmitDecision);
+    assert!(decision_result.ok, "{}", decision_result.message);
+
+    let mut pause = base_cmd("run-request-changes-resume");
+    pause.status_message = Some("Run blocked: gate rejected".to_string());
+    let pause_result = mutate(&mut runs, pause, RunMutationKind::Pause);
+    assert!(pause_result.ok, "{}", pause_result.message);
+
+    let advance_while_paused = mutate(
+        &mut runs,
+        base_cmd("run-request-changes-resume"),
+        RunMutationKind::AdvancePhase,
+    );
+    assert!(!advance_while_paused.ok);
+    assert!(advance_while_paused.message.contains("run is not active"));
+
+    let mut resume = base_cmd("run-request-changes-resume");
+    resume.status_message = Some("Run resumed".to_string());
+    let resume_result = mutate(&mut runs, resume, RunMutationKind::Resume);
+    assert!(resume_result.ok, "{}", resume_result.message);
+
+    let advance_after_resume = mutate(
+        &mut runs,
+        base_cmd("run-request-changes-resume"),
+        RunMutationKind::AdvancePhase,
+    );
+    assert!(advance_after_resume.ok, "{}", advance_after_resume.message);
+
+    let run = runs.values().next().unwrap();
+    assert_eq!(run.status, RunStatus::Active);
+    assert_eq!(run.current_phase_index, 1);
+    assert_eq!(run.status_message.as_deref(), Some("Run resumed"));
+}
+
+#[test]
 fn advance_past_last_phase_completes_run() {
     let mut runs = empty_runs();
     apply_run_mutation(&mut runs, create_command("run-001", "execution_only"));

--- a/core/capacitor-core/src/reduce/run_reducer/tests/start_heartbeat.rs
+++ b/core/capacitor-core/src/reduce/run_reducer/tests/start_heartbeat.rs
@@ -133,6 +133,25 @@ fn heartbeat_on_created_run_succeeds() {
 }
 
 #[test]
+fn pause_updates_status_message() {
+    let mut runs = empty_runs();
+    apply_run_mutation(&mut runs, create_command("run-001", "execution_only"));
+    start_run(&mut runs, "run-001");
+
+    let mut cmd = base_cmd("run-001");
+    cmd.status_message = Some("Run blocked: gate rejected".to_string());
+    let result = mutate(&mut runs, cmd, RunMutationKind::Pause);
+    assert!(result.ok, "{}", result.message);
+
+    let run = runs.values().next().unwrap();
+    assert_eq!(run.status, RunStatus::Paused);
+    assert_eq!(
+        run.status_message.as_deref(),
+        Some("Run blocked: gate rejected")
+    );
+}
+
+#[test]
 fn full_lifecycle_create_start_heartbeat_advance() {
     let mut runs = empty_runs();
     apply_run_mutation(&mut runs, create_command("run-001", "shape_and_execute"));

--- a/core/capacitor-core/src/runtime/projects.rs
+++ b/core/capacitor-core/src/runtime/projects.rs
@@ -292,7 +292,7 @@ pub(crate) fn load_projects_with_storage(storage: &StorageConfig) -> Result<Vec<
 
     let _ = save_stats_cache_with_storage(storage, &stats_cache);
 
-    projects.sort_by(|a, b| b.1.cmp(&a.1));
+    projects.sort_by_key(|(_, sort_time)| std::cmp::Reverse(*sort_time));
 
     Ok(projects.into_iter().map(|(p, _)| p).collect())
 }

--- a/core/capacitor-core/tests/method_runner/run_status_reporter.rs
+++ b/core/capacitor-core/tests/method_runner/run_status_reporter.rs
@@ -315,6 +315,99 @@ fn execute_run_reports_spec_status_messages() {
 }
 
 #[test]
+fn rejected_gate_reports_pause_instead_of_fail() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let source = write_definition(&temp, &gated_method_yaml());
+    let reporter = SpyRunStatusReporter::default();
+    let interactive = FakeInteractiveIO::new("rejected");
+
+    let result = execute_run_with_reporter(
+        &source,
+        &FakePromptBuilder,
+        &FakeWorkerDispatcher,
+        &interactive,
+        &reporter,
+    );
+    assert!(result.is_err(), "rejected gate should block execution");
+
+    let events = reporter.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == RunStatusEventKind::Pause),
+        "expected rejected gate to pause the runtime run: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.kind == RunStatusEventKind::Fail),
+        "rejected gate should not report a terminal runtime failure: {events:?}"
+    );
+}
+
+#[test]
+fn resumed_rejected_gate_reports_pause_instead_of_fail() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let source = write_definition(&temp, &gated_method_yaml());
+
+    execute_run_with_reporter(
+        &source,
+        &FakePromptBuilder,
+        &FakeWorkerDispatcher,
+        &FakeInteractiveIO::new("approved"),
+        &SpyRunStatusReporter::default(),
+    )
+    .expect("seed complete gated run");
+
+    let paths = MethodRunPaths::new(&source.execution_root);
+    let events_path = paths.events_log();
+    let events = recover_events(&events_path).expect("recover events");
+    let gate_index = events
+        .iter()
+        .position(|event| event.kind == MethodEventKind::GateEvaluated)
+        .expect("expected gate evaluation event");
+
+    {
+        let mut file = std::fs::File::create(&events_path).expect("rewrite events log");
+        for event in &events[..gate_index] {
+            writeln!(
+                file,
+                "{}",
+                serde_json::to_string(event).expect("serialize event")
+            )
+            .expect("write truncated event");
+        }
+    }
+
+    let reporter = SpyRunStatusReporter::default();
+    let result = resume_run_with_reporter(
+        &source.execution_root,
+        &FakePromptBuilder,
+        &FakeWorkerDispatcher,
+        &FakeInteractiveIO::new("rejected"),
+        &reporter,
+    );
+    assert!(
+        result.is_err(),
+        "rejected resumed gate should block execution"
+    );
+
+    let events = reporter.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == RunStatusEventKind::Pause),
+        "expected rejected resumed gate to pause the runtime run: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.kind == RunStatusEventKind::Fail),
+        "rejected resumed gate should not report a terminal runtime failure: {events:?}"
+    );
+}
+
+#[test]
 fn resume_run_emits_immediate_recovered_phase_heartbeat() {
     let temp = tempfile::tempdir().expect("tempdir");
     let source = write_definition(&temp, &two_phase_method_yaml());
@@ -525,7 +618,7 @@ fn reporter_panics_do_not_abort_run_execution() {
 #[test]
 fn runtime_reporter_posts_mutate_commands_with_expected_mapping() {
     let auth_token = "secret-token";
-    let server = StubMutationServer::spawn(auth_token, 3);
+    let server = StubMutationServer::spawn(auth_token, 4);
     let reporter = RuntimeRunStatusReporter::new(
         server.endpoint(auth_token),
         PathBuf::from("/tmp/project"),
@@ -540,22 +633,30 @@ fn runtime_reporter_posts_mutate_commands_with_expected_mapping() {
         RunStatusEventKind::Heartbeat,
         Some("Composing prompt".to_string()),
     ));
+    reporter.report(RunStatusEvent::new(
+        RunStatusEventKind::Pause,
+        Some("Run blocked: gate rejected".to_string()),
+    ));
     reporter.report(RunStatusEvent::new(RunStatusEventKind::Complete, None));
 
     let request_a = server.captured_request();
     let request_b = server.captured_request();
     let request_c = server.captured_request();
+    let request_d = server.captured_request();
 
     assert_eq!(request_a.request_line, "POST /runtime/run/mutate HTTP/1.1");
     assert_eq!(request_b.request_line, "POST /runtime/run/mutate HTTP/1.1");
     assert_eq!(request_c.request_line, "POST /runtime/run/mutate HTTP/1.1");
+    assert_eq!(request_d.request_line, "POST /runtime/run/mutate HTTP/1.1");
 
     let command_a: MutateRunCommand =
         serde_json::from_str(&request_a.body).expect("parse start command");
     let command_b: MutateRunCommand =
         serde_json::from_str(&request_b.body).expect("parse heartbeat command");
     let command_c: MutateRunCommand =
-        serde_json::from_str(&request_c.body).expect("parse complete command");
+        serde_json::from_str(&request_c.body).expect("parse pause command");
+    let command_d: MutateRunCommand =
+        serde_json::from_str(&request_d.body).expect("parse complete command");
 
     assert_eq!(command_a.kind, RunMutationKind::Start);
     assert_eq!(command_a.status_message.as_deref(), Some("Run started"));
@@ -564,6 +665,11 @@ fn runtime_reporter_posts_mutate_commands_with_expected_mapping() {
         command_b.status_message.as_deref(),
         Some("Composing prompt")
     );
-    assert_eq!(command_c.kind, RunMutationKind::Complete);
-    assert!(command_c.status_message.is_none());
+    assert_eq!(command_c.kind, RunMutationKind::Pause);
+    assert_eq!(
+        command_c.status_message.as_deref(),
+        Some("Run blocked: gate rejected")
+    );
+    assert_eq!(command_d.kind, RunMutationKind::Complete);
+    assert!(command_d.status_message.is_none());
 }

--- a/core/capacitor-core/tests/method_runner/run_status_reporter.rs
+++ b/core/capacitor-core/tests/method_runner/run_status_reporter.rs
@@ -19,6 +19,7 @@ use capacitor_core::method_runner::resume::resume_run_with_reporter;
 use capacitor_core::method_runner::run_status_reporter::{
     RunStatusEvent, RunStatusEventKind, RunStatusReporter, RuntimeRunStatusReporter,
 };
+use capacitor_core::method_runner::state::RunStatus;
 use capacitor_core::method_runner::storage::MethodRunPaths;
 use capacitor_core::runtime::service::RuntimeServiceEndpoint;
 
@@ -233,6 +234,49 @@ method:
     .to_string()
 }
 
+fn two_phase_gated_method_yaml() -> String {
+    r#"schema_version: "1"
+method:
+  id: reporter-two-phase-gated-test
+  version: "2026-03-26"
+  title: Reporter Two Phase Gated Test
+  defaults:
+    max_attempts: 1
+    completion_policy: all_complete
+  phases:
+    - id: phase-1
+      title: Discovery
+      execution: serial
+      gate:
+        id: discovery-gate
+        type: approval
+      steps:
+        - id: step-1
+          title: First pass
+          action: dispatch
+          outputs:
+            result:
+              path: artifacts/first.md
+              type: markdown
+          dispatch:
+            instructions: Do the first thing.
+    - id: phase-2
+      title: Implementation
+      execution: serial
+      steps:
+        - id: step-2
+          title: Final pass
+          action: dispatch
+          outputs:
+            result:
+              path: artifacts/final.md
+              type: markdown
+          dispatch:
+            instructions: Do the final thing.
+"#
+    .to_string()
+}
+
 fn write_definition(temp: &tempfile::TempDir, yaml: &str) -> DefinitionSource {
     let definition_path = temp.path().join("method.yaml");
     std::fs::write(&definition_path, yaml).expect("write definition");
@@ -321,14 +365,23 @@ fn rejected_gate_reports_pause_instead_of_fail() {
     let reporter = SpyRunStatusReporter::default();
     let interactive = FakeInteractiveIO::new("rejected");
 
-    let result = execute_run_with_reporter(
+    let state = execute_run_with_reporter(
         &source,
         &FakePromptBuilder,
         &FakeWorkerDispatcher,
         &interactive,
         &reporter,
+    )
+    .expect("rejected gate should produce a controlled blocked handoff");
+    assert_eq!(state.status, RunStatus::Blocked);
+
+    let paths = MethodRunPaths::new(&source.execution_root);
+    let method_events = recover_events(&paths.events_log()).expect("recover events");
+    assert_eq!(
+        method_events.last().map(|event| event.kind),
+        Some(MethodEventKind::RunBlocked),
+        "blocked gate should persist a run-blocked lifecycle event"
     );
-    assert!(result.is_err(), "rejected gate should block execution");
 
     let events = reporter.events();
     assert!(
@@ -342,6 +395,12 @@ fn rejected_gate_reports_pause_instead_of_fail() {
             .iter()
             .any(|event| event.kind == RunStatusEventKind::Fail),
         "rejected gate should not report a terminal runtime failure: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.kind == RunStatusEventKind::Complete),
+        "rejected gate should not report runtime completion: {events:?}"
     );
 }
 
@@ -380,16 +439,21 @@ fn resumed_rejected_gate_reports_pause_instead_of_fail() {
     }
 
     let reporter = SpyRunStatusReporter::default();
-    let result = resume_run_with_reporter(
+    let state = resume_run_with_reporter(
         &source.execution_root,
         &FakePromptBuilder,
         &FakeWorkerDispatcher,
         &FakeInteractiveIO::new("rejected"),
         &reporter,
-    );
-    assert!(
-        result.is_err(),
-        "rejected resumed gate should block execution"
+    )
+    .expect("rejected resumed gate should produce a controlled blocked handoff");
+    assert_eq!(state.status, RunStatus::Blocked);
+
+    let method_events = recover_events(&events_path).expect("recover resumed events");
+    assert_eq!(
+        method_events.last().map(|event| event.kind),
+        Some(MethodEventKind::RunBlocked),
+        "resumed rejected gate should persist a run-blocked lifecycle event"
     );
 
     let events = reporter.events();
@@ -404,6 +468,78 @@ fn resumed_rejected_gate_reports_pause_instead_of_fail() {
             .iter()
             .any(|event| event.kind == RunStatusEventKind::Fail),
         "rejected resumed gate should not report a terminal runtime failure: {events:?}"
+    );
+}
+
+#[test]
+fn resume_blocked_gate_reports_resume_before_advancing_phase() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let source = write_definition(&temp, &two_phase_gated_method_yaml());
+
+    let blocked_state = execute_run_with_reporter(
+        &source,
+        &FakePromptBuilder,
+        &FakeWorkerDispatcher,
+        &FakeInteractiveIO::new("rejected"),
+        &SpyRunStatusReporter::default(),
+    )
+    .expect("seed blocked gated run");
+    assert_eq!(blocked_state.status, RunStatus::Blocked);
+
+    let reporter = SpyRunStatusReporter::default();
+    let resumed_state = resume_run_with_reporter(
+        &source.execution_root,
+        &FakePromptBuilder,
+        &FakeWorkerDispatcher,
+        &FakeInteractiveIO::new("approved"),
+        &reporter,
+    )
+    .expect("resume blocked run");
+    assert_eq!(resumed_state.status, RunStatus::Completed);
+
+    let events = reporter.events();
+    let resume_index = events
+        .iter()
+        .position(|event| event.kind == RunStatusEventKind::Resume)
+        .expect("expected runtime resume event");
+    let advance_index = events
+        .iter()
+        .position(|event| event.kind == RunStatusEventKind::AdvancePhase)
+        .expect("expected runtime advance event");
+    assert!(
+        resume_index < advance_index,
+        "runtime resume must precede advance: {events:?}"
+    );
+
+    let paths = MethodRunPaths::new(&source.execution_root);
+    let method_events = recover_events(&paths.events_log()).expect("recover events");
+    let phase_blocked_index = method_events
+        .iter()
+        .position(|event| event.kind == MethodEventKind::PhaseBlocked)
+        .expect("expected phase blocked event");
+    let phase_restarted_index = method_events
+        .iter()
+        .enumerate()
+        .skip(phase_blocked_index + 1)
+        .find(|(_, event)| {
+            event.kind == MethodEventKind::PhaseStarted
+                && event.phase_id.as_deref() == Some("phase-1")
+        })
+        .map(|(index, _)| index)
+        .expect("expected blocked phase to restart before completion");
+    let phase_completed_index = method_events
+        .iter()
+        .enumerate()
+        .skip(phase_restarted_index + 1)
+        .find(|(_, event)| {
+            event.kind == MethodEventKind::PhaseCompleted
+                && event.phase_id.as_deref() == Some("phase-1")
+        })
+        .map(|(index, _)| index)
+        .expect("expected restarted phase to complete");
+    assert!(
+        phase_restarted_index < phase_completed_index,
+        "blocked phase must restart before completing"
     );
 }
 
@@ -618,7 +754,7 @@ fn reporter_panics_do_not_abort_run_execution() {
 #[test]
 fn runtime_reporter_posts_mutate_commands_with_expected_mapping() {
     let auth_token = "secret-token";
-    let server = StubMutationServer::spawn(auth_token, 4);
+    let server = StubMutationServer::spawn(auth_token, 5);
     let reporter = RuntimeRunStatusReporter::new(
         server.endpoint(auth_token),
         PathBuf::from("/tmp/project"),
@@ -637,17 +773,23 @@ fn runtime_reporter_posts_mutate_commands_with_expected_mapping() {
         RunStatusEventKind::Pause,
         Some("Run blocked: gate rejected".to_string()),
     ));
+    reporter.report(RunStatusEvent::new(
+        RunStatusEventKind::Resume,
+        Some("Run resumed".to_string()),
+    ));
     reporter.report(RunStatusEvent::new(RunStatusEventKind::Complete, None));
 
     let request_a = server.captured_request();
     let request_b = server.captured_request();
     let request_c = server.captured_request();
     let request_d = server.captured_request();
+    let request_e = server.captured_request();
 
     assert_eq!(request_a.request_line, "POST /runtime/run/mutate HTTP/1.1");
     assert_eq!(request_b.request_line, "POST /runtime/run/mutate HTTP/1.1");
     assert_eq!(request_c.request_line, "POST /runtime/run/mutate HTTP/1.1");
     assert_eq!(request_d.request_line, "POST /runtime/run/mutate HTTP/1.1");
+    assert_eq!(request_e.request_line, "POST /runtime/run/mutate HTTP/1.1");
 
     let command_a: MutateRunCommand =
         serde_json::from_str(&request_a.body).expect("parse start command");
@@ -656,7 +798,9 @@ fn runtime_reporter_posts_mutate_commands_with_expected_mapping() {
     let command_c: MutateRunCommand =
         serde_json::from_str(&request_c.body).expect("parse pause command");
     let command_d: MutateRunCommand =
-        serde_json::from_str(&request_d.body).expect("parse complete command");
+        serde_json::from_str(&request_d.body).expect("parse resume command");
+    let command_e: MutateRunCommand =
+        serde_json::from_str(&request_e.body).expect("parse complete command");
 
     assert_eq!(command_a.kind, RunMutationKind::Start);
     assert_eq!(command_a.status_message.as_deref(), Some("Run started"));
@@ -670,6 +814,8 @@ fn runtime_reporter_posts_mutate_commands_with_expected_mapping() {
         command_c.status_message.as_deref(),
         Some("Run blocked: gate rejected")
     );
-    assert_eq!(command_d.kind, RunMutationKind::Complete);
-    assert!(command_d.status_message.is_none());
+    assert_eq!(command_d.kind, RunMutationKind::Resume);
+    assert_eq!(command_d.status_message.as_deref(), Some("Run resumed"));
+    assert_eq!(command_e.kind, RunMutationKind::Complete);
+    assert!(command_e.status_message.is_none());
 }

--- a/core/capacitor-core/tests/method_runner/step8_batch_c.rs
+++ b/core/capacitor-core/tests/method_runner/step8_batch_c.rs
@@ -11,7 +11,7 @@ use capacitor_core::method_runner::adapters::{
 };
 use capacitor_core::method_runner::definition::DefinitionSource;
 use capacitor_core::method_runner::events::{recover_events, MethodEventKind};
-use capacitor_core::method_runner::executor::{execute_run, RunError};
+use capacitor_core::method_runner::executor::execute_run;
 use capacitor_core::method_runner::resume::resume_run;
 use capacitor_core::method_runner::state::{rebuild_state, PhaseStatus, RunStatus};
 use capacitor_core::method_runner::storage::MethodRunPaths;
@@ -76,26 +76,25 @@ fn approval_gate_rejected_phase_blocked() {
     // Gate will prompt via InteractiveIO — respond with "rejected"
     let interactive_io = FakeInteractiveIO::new("rejected");
 
-    let result = execute_run(&source, &prompt_builder, &dispatcher, &interactive_io);
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    match err {
-        RunError::PhaseGateBlocked {
-            phase_id,
-            gate_id,
-            reason,
-        } => {
-            assert_eq!(phase_id, "build");
-            assert_eq!(gate_id, "build-gate");
-            assert_eq!(reason, "gate rejected");
-        }
-        other => panic!("expected PhaseGateBlocked, got: {other:?}"),
-    }
+    let state = execute_run(&source, &prompt_builder, &dispatcher, &interactive_io)
+        .expect("rejected gate should return a blocked handoff state");
+    assert_eq!(state.status, RunStatus::Blocked);
 
     // Verify state on disk shows phase blocked
     let paths = MethodRunPaths::new(tmp.path());
     let events = recover_events(&paths.events_log()).unwrap();
     let state = capacitor_core::method_runner::state::project(&events).unwrap();
+    assert_eq!(
+        events.last().map(|event| event.kind),
+        Some(MethodEventKind::RunBlocked)
+    );
+    let blocked_reason = events
+        .iter()
+        .find(|event| event.kind == MethodEventKind::PhaseBlocked)
+        .and_then(|event| event.payload.get("reason"))
+        .and_then(|reason| reason.as_str())
+        .expect("phase blocked reason");
+    assert_eq!(blocked_reason, "gate rejected");
     let build_phase = state.phases.get("build").expect("build phase exists");
     assert_eq!(build_phase.status, PhaseStatus::Blocked);
 
@@ -182,34 +181,20 @@ method:
     let dispatcher = FakeWorkerDispatcher;
     let interactive_io = FakeInteractiveIO::new("approved");
 
-    let result = execute_run(&source, &prompt_builder, &dispatcher, &interactive_io);
-    assert!(result.is_err());
-
-    let err = result.unwrap_err();
-    match err {
-        RunError::PhaseGateBlocked {
-            phase_id,
-            gate_id,
-            reason,
-        } => {
-            assert_eq!(phase_id, "build");
-            assert_eq!(gate_id, "outputs-gate");
-            assert!(
-                reason.contains("validation failed"),
-                "reason should mention validation_failed: {reason}"
-            );
-            assert!(
-                reason.contains("nonexistent_output"),
-                "reason should mention the missing output: {reason}"
-            );
-        }
-        other => panic!("expected PhaseGateBlocked, got: {other:?}"),
-    }
+    let blocked_state = execute_run(&source, &prompt_builder, &dispatcher, &interactive_io)
+        .expect("validation failure should return a blocked handoff state");
+    assert_eq!(blocked_state.status, RunStatus::Blocked);
 
     // Verify gate event shows validation_failed
     let paths = MethodRunPaths::new(tmp.path());
     let events = recover_events(&paths.events_log()).unwrap();
     let state = capacitor_core::method_runner::state::project(&events).unwrap();
+    let blocked_reason = events
+        .iter()
+        .find(|event| event.kind == MethodEventKind::PhaseBlocked)
+        .and_then(|event| event.payload.get("reason"))
+        .and_then(|reason| reason.as_str())
+        .expect("phase blocked reason");
     let gate_result = state
         .phases
         .get("build")
@@ -218,6 +203,14 @@ method:
         .as_ref()
         .unwrap();
     assert_eq!(gate_result.outcome, "validation_failed");
+    assert!(
+        blocked_reason.contains("nonexistent_output"),
+        "reason should mention the missing output: {blocked_reason}"
+    );
+    assert_eq!(
+        events.last().map(|event| event.kind),
+        Some(MethodEventKind::RunBlocked)
+    );
 }
 
 // ============================================================================
@@ -235,30 +228,20 @@ fn pipeline_clean_gate_blocked() {
     let dispatcher = FakeWorkerDispatcher;
     let interactive_io = FakeInteractiveIO::new("approved");
 
-    let result = execute_run(&source, &prompt_builder, &dispatcher, &interactive_io);
-    assert!(result.is_err());
-
-    let err = result.unwrap_err();
-    match err {
-        RunError::PhaseGateBlocked {
-            phase_id,
-            gate_id,
-            reason,
-        } => {
-            assert_eq!(phase_id, "build");
-            assert_eq!(gate_id, "pipeline-gate");
-            assert!(
-                reason.contains("pipeline_clean requires pipeline-execute"),
-                "reason should mention v1 limitation: {reason}"
-            );
-        }
-        other => panic!("expected PhaseGateBlocked, got: {other:?}"),
-    }
+    let blocked_state = execute_run(&source, &prompt_builder, &dispatcher, &interactive_io)
+        .expect("pipeline_clean gate should return a blocked handoff state");
+    assert_eq!(blocked_state.status, RunStatus::Blocked);
 
     // Verify gate event shows waiting outcome
     let paths = MethodRunPaths::new(tmp.path());
     let events = recover_events(&paths.events_log()).unwrap();
     let state = capacitor_core::method_runner::state::project(&events).unwrap();
+    let blocked_reason = events
+        .iter()
+        .find(|event| event.kind == MethodEventKind::PhaseBlocked)
+        .and_then(|event| event.payload.get("reason"))
+        .and_then(|reason| reason.as_str())
+        .expect("phase blocked reason");
     let gate_result = state
         .phases
         .get("build")
@@ -267,6 +250,14 @@ fn pipeline_clean_gate_blocked() {
         .as_ref()
         .unwrap();
     assert_eq!(gate_result.outcome, "waiting");
+    assert!(
+        blocked_reason.contains("pipeline_clean requires pipeline-execute"),
+        "reason should mention v1 limitation: {blocked_reason}"
+    );
+    assert_eq!(
+        events.last().map(|event| event.kind),
+        Some(MethodEventKind::RunBlocked)
+    );
 }
 
 // ============================================================================

--- a/core/capacitor-core/tests/run_kernel_contract.rs
+++ b/core/capacitor-core/tests/run_kernel_contract.rs
@@ -695,7 +695,7 @@ fn scenario_submit_decision_archives_decided_checkpoint_history() {
         .iter()
         .find(|run| run.id == "run-checkpoint-history")
         .expect("run exists");
-    assert_eq!(run.status, RunStatus::Active);
+    assert_eq!(run.status, RunStatus::Paused);
     assert!(run.active_checkpoint.is_none());
     assert_eq!(run.past_checkpoints.len(), 1);
     let decided = &run.past_checkpoints[0];

--- a/docs/orchestrator/checkpoint-bridge.md
+++ b/docs/orchestrator/checkpoint-bridge.md
@@ -39,7 +39,7 @@ The checkpoint bridge connects method runner gates to the run kernel checkpoint 
    - HTTP handler: `core/hud-hook/src/handlers.rs:498-535`
    - Relay logic: `core/hud-hook/src/checkpoint_bridge_relay.rs`
 
-9. **Bridge polls and unblocks** -- `BridgeInteractiveIO::capture_response()` polls for the decision file at 500ms intervals. When found, it normalizes the action ("approve"/"approved" -> "approved", "request_changes"/"rejected" -> "rejected", unknown -> "rejected"), clears `current_gate_id`, deletes the decision file, and returns the normalized response to the gate evaluator.
+9. **Bridge polls and unblocks** -- `BridgeInteractiveIO::capture_response()` polls for the decision file at 500ms intervals. When found, it normalizes the action ("approve"/"approved" -> "approved", "request_changes"/"rejected" -> "rejected", unknown -> "rejected"), clears `current_gate_id`, deletes the decision file, and returns the normalized response to the gate evaluator. An approval lets the method runner continue. A request-changes decision blocks the gate and reports a paused runtime run with a "Run blocked: ..." status message instead of reporting terminal failure.
    - Poll loop: `checkpoint_bridge.rs:197-239`
    - Normalization: `checkpoint_bridge.rs:116-128`
 
@@ -116,11 +116,17 @@ The bridge relay is part of the successful `SubmitDecision` commit for bridge-ma
 
 The key invariant: bridge-managed status is runtime truth (`active_checkpoint.decision_relay == checkpoint_bridge`), not inferred from filesystem marker presence. For bridge-managed checkpoints, the runtime does not accept and clear a `SubmitDecision` unless the bridge decision file was committed successfully.
 
-Accepted decisions move the decided checkpoint from `active_checkpoint` into the run's bounded `past_checkpoints` history, preserving the decision, timestamp, and review metadata for snapshot consumers. The run kernel keeps the most recent 50 decided checkpoints per run.
+Accepted decisions move the decided checkpoint from `active_checkpoint` into the run's bounded `past_checkpoints` history, preserving the decision, timestamp, and review metadata for snapshot consumers. Approvals resume the run as `active`; request-changes decisions leave the run `paused` with no active checkpoint so the runtime remains non-terminal while the method runner records the blocked gate. The run kernel keeps the most recent 50 decided checkpoints per run.
+
+Request-changes is still a blocked-gate handoff, not a full multi-round worker retry loop. The retry loop remains a separate method-runner design step.
+
+A paused run with no active checkpoint cannot advance phases until it is resumed, preventing a request-changes decision from being bypassed by a stray `AdvancePhase` mutation.
+
+Swift review-window targeting still requires `activeCheckpoint`, but project-card projection treats fresh paused runs with or without an active checkpoint as waiting so blocked request-changes runs remain visible.
 
 ### Timeout Behavior
 
-`DECISION_POLL_TIMEOUT` is 3600 seconds (1 hour). Defined at `checkpoint_bridge.rs:28`. After timeout, `capture_response` returns `InteractiveResponse { body: "rejected" }` so the method runner can proceed rather than blocking forever. The poll interval is 500ms (`checkpoint_bridge.rs:223`).
+`DECISION_POLL_TIMEOUT` is 3600 seconds (1 hour). Defined at `checkpoint_bridge.rs:28`. After timeout, `capture_response` returns `InteractiveResponse { body: "rejected" }` so the method runner records a blocked gate rather than waiting forever. The poll interval is 500ms (`checkpoint_bridge.rs:223`).
 
 ## CLI Integration
 
@@ -181,6 +187,21 @@ This identity is what allows the relay to find the correct pending marker: the S
 | `t15_bridge_falls_back_to_prompt_when_mutation_rejected` (line 1359) | Runtime rejection triggers fallback to interactive prompt (fail-closed) |
 | `t15_bridge_falls_back_to_prompt_when_server_unreachable` (line 1399) | Unreachable server triggers fallback to interactive prompt (fail-closed) |
 
+### `core/capacitor-core/tests/method_runner/run_status_reporter.rs`
+
+| Test | What it proves |
+|------|---------------|
+| `rejected_gate_reports_pause_instead_of_fail` | A rejected human gate reports a paused runtime run instead of terminal failure |
+| `resumed_rejected_gate_reports_pause_instead_of_fail` | The same paused reporting holds when the gate is reached through method-runner resume |
+| `runtime_reporter_posts_mutate_commands_with_expected_mapping` | Reporter `Pause` events map to runtime `Pause` mutations and carry the block message |
+
+### `core/capacitor-core/src/reduce/run_reducer/tests/lifecycle.rs`
+
+| Test | What it proves |
+|------|---------------|
+| `submit_request_changes_archives_checkpoint_and_keeps_run_paused` | Runtime request-changes decisions archive the checkpoint without resuming the run |
+| `advance_phase_rejects_paused_run_without_active_checkpoint` | A paused run cannot advance phases without an explicit resume |
+
 ### `core/hud-hook/tests/serve_integration.rs`
 
 | Test | What it proves |
@@ -202,3 +223,9 @@ This identity is what allows the relay to find the correct pending marker: the S
 | `testFreshRuntimeSnapshotChoosesOldestPausedRunCheckpointFirst` (line 50) | Queue ordering selects oldest checkpoint first |
 | `testFreshRuntimeSnapshotPresentsNextPausedRunCheckpointAfterFirstCheckpointClears` (line 87) | After a checkpoint clears, the next queued checkpoint surfaces automatically |
 | `testSubmitRunCheckpointDecisionMutatesRuntimeRunWithCheckpointIdentity` (line 146) | Decision submission sends correct mutation payload including `checkpoint_id` and `decision_action` |
+
+### `apps/swift/Tests/CapacitorTests/ProjectRunVisualStateResolverTests.swift`
+
+| Test | What it proves |
+|------|---------------|
+| `testPausedRunWithoutCheckpointSurfacesAsWaiting` | Project-card projection keeps request-changes blocked runs visible after their active checkpoint is archived |

--- a/docs/orchestrator/checkpoint-bridge.md
+++ b/docs/orchestrator/checkpoint-bridge.md
@@ -39,7 +39,7 @@ The checkpoint bridge connects method runner gates to the run kernel checkpoint 
    - HTTP handler: `core/hud-hook/src/handlers.rs:498-535`
    - Relay logic: `core/hud-hook/src/checkpoint_bridge_relay.rs`
 
-9. **Bridge polls and unblocks** -- `BridgeInteractiveIO::capture_response()` polls for the decision file at 500ms intervals. When found, it normalizes the action ("approve"/"approved" -> "approved", "request_changes"/"rejected" -> "rejected", unknown -> "rejected"), clears `current_gate_id`, deletes the decision file, and returns the normalized response to the gate evaluator. An approval lets the method runner continue. A request-changes decision blocks the gate and reports a paused runtime run with a "Run blocked: ..." status message instead of reporting terminal failure.
+9. **Bridge polls and unblocks** -- `BridgeInteractiveIO::capture_response()` polls for the decision file at 500ms intervals. When found, it normalizes the action ("approve"/"approved" -> "approved", "request_changes"/"rejected" -> "rejected", unknown -> "rejected"), clears `current_gate_id`, deletes the decision file, and returns the normalized response to the gate evaluator. An approval lets the method runner continue. A request-changes decision records `PhaseBlocked` + `RunBlocked`, reports runtime `Pause` with a "Run blocked: ..." status message, and returns a controlled blocked handoff rather than an execution error.
    - Poll loop: `checkpoint_bridge.rs:197-239`
    - Normalization: `checkpoint_bridge.rs:116-128`
 
@@ -122,6 +122,10 @@ Request-changes is still a blocked-gate handoff, not a full multi-round worker r
 
 A paused run with no active checkpoint cannot advance phases until it is resumed, preventing a request-changes decision from being bypassed by a stray `AdvancePhase` mutation.
 
+Method-runner resume is explicit: resuming a blocked method run appends `RunStarted` in the method-runner event log to move `Blocked -> Running`, reports runtime `Resume`, restarts the blocked phase with `PhaseStarted`, and only then may report `AdvancePhase`. This keeps the runtime reducer and method-runner projection in the same lifecycle order.
+
+The method-runner CLI exits successfully for controlled `Blocked` handoffs. Process supervision treats nonzero exit as infrastructure/execution failure, but runtime truth still comes from runtime mutations and snapshots, not from filesystem relay markers or process exit alone.
+
 Swift review-window targeting still requires `activeCheckpoint`, but project-card projection treats fresh paused runs with or without an active checkpoint as waiting so blocked request-changes runs remain visible.
 
 ### Timeout Behavior
@@ -191,9 +195,10 @@ This identity is what allows the relay to find the correct pending marker: the S
 
 | Test | What it proves |
 |------|---------------|
-| `rejected_gate_reports_pause_instead_of_fail` | A rejected human gate reports a paused runtime run instead of terminal failure |
-| `resumed_rejected_gate_reports_pause_instead_of_fail` | The same paused reporting holds when the gate is reached through method-runner resume |
-| `runtime_reporter_posts_mutate_commands_with_expected_mapping` | Reporter `Pause` events map to runtime `Pause` mutations and carry the block message |
+| `rejected_gate_reports_pause_instead_of_fail` | A rejected human gate returns a blocked handoff, persists `RunBlocked`, and reports runtime `Pause` instead of terminal failure |
+| `resumed_rejected_gate_reports_pause_instead_of_fail` | The same controlled blocked handoff holds when the gate is reached through method-runner resume |
+| `resume_blocked_gate_reports_resume_before_advancing_phase` | Resume reports runtime `Resume` before `AdvancePhase` and restarts a blocked phase before completing it |
+| `runtime_reporter_posts_mutate_commands_with_expected_mapping` | Reporter `Pause` and `Resume` events map to matching runtime mutations with status messages |
 
 ### `core/capacitor-core/src/reduce/run_reducer/tests/lifecycle.rs`
 
@@ -201,6 +206,7 @@ This identity is what allows the relay to find the correct pending marker: the S
 |------|---------------|
 | `submit_request_changes_archives_checkpoint_and_keeps_run_paused` | Runtime request-changes decisions archive the checkpoint without resuming the run |
 | `advance_phase_rejects_paused_run_without_active_checkpoint` | A paused run cannot advance phases without an explicit resume |
+| `request_changes_pause_requires_resume_before_phase_advance` | `Pause -> AdvancePhase` is rejected, while `Resume -> AdvancePhase` succeeds after request-changes |
 
 ### `core/hud-hook/tests/serve_integration.rs`
 


### PR DESCRIPTION
## Summary
- normalize approve/request-changes checkpoint decisions before applying run state transitions
- archive request-changes checkpoints into bounded history while leaving the run paused until explicit resume
- report blocked method-runner gates as runtime pauses instead of terminal failures
- keep paused blocked runs visible in Swift project-card projection and document the relay/debug bridge invariants

## Verification
- cargo test -p capacitor-core --lib --tests
- cargo test --workspace --lib --tests
- cargo test -p capacitor-core --bin method-runner
- cargo clippy -- -D warnings
- cargo build -p capacitor-core --release
- swift test --package-path apps/swift
- ./scripts/verify/verify.sh --bootstrap
- ./scripts/verify/verify.sh --layers 1
- git diff --check
- ./scripts/dev/restart-alpha-stable.sh
- pre-commit hooks passed during commit

## Notes
This branch intentionally stops at blocked-gate pause semantics. The true multi-round request-changes retry loop should be implemented as a follow-up slice.