### PR TITLE
Implement multi-round request-changes retries

### DIFF
--- a/core/capacitor-core/src/method_runner/executor.rs
+++ b/core/capacitor-core/src/method_runner/executor.rs
@@ -619,6 +619,14 @@ pub(crate) fn execute_step_public_with_reporter(
     context: StepExecutionContext<'_>,
     reporter: &dyn RunStatusReporter,
 ) -> Result<(), RunError> {
+    execute_step_public_with_reporter_from_attempt(context, reporter, 1)
+}
+
+pub(crate) fn execute_step_public_with_reporter_from_attempt(
+    context: StepExecutionContext<'_>,
+    reporter: &dyn RunStatusReporter,
+    first_attempt: u32,
+) -> Result<(), RunError> {
     let step = context.step_definition;
     let mut context = context.with_reporter(reporter);
 
@@ -634,12 +642,19 @@ pub(crate) fn execute_step_public_with_reporter(
         )?;
         return Err(RunError::PipelineExecuteBlocked(step.id.clone()));
     }
-    execute_step(&mut context)
+    execute_step_with_first_attempt(&mut context, first_attempt)
 }
 
 fn execute_step(ctx: &mut ReportedStepExecutionContext<'_>) -> Result<(), RunError> {
+    execute_step_with_first_attempt(ctx, 1)
+}
+
+fn execute_step_with_first_attempt(
+    ctx: &mut ReportedStepExecutionContext<'_>,
+    first_attempt: u32,
+) -> Result<(), RunError> {
     match ctx.step.step_definition.action {
-        ActionKind::Dispatch => execute_dispatch_step(ctx),
+        ActionKind::Dispatch => execute_dispatch_step(ctx, first_attempt),
         ActionKind::Synthesis => execute_synthesis_step(
             ctx.step.paths,
             ctx.step.events_path,
@@ -647,8 +662,9 @@ fn execute_step(ctx: &mut ReportedStepExecutionContext<'_>) -> Result<(), RunErr
             &mut *ctx.step.current_seq,
             ctx.step.phase_id,
             ctx.step.step_definition,
+            first_attempt,
         ),
-        ActionKind::Interactive => execute_interactive_step(ctx),
+        ActionKind::Interactive => execute_interactive_step(ctx, first_attempt),
         ActionKind::PipelineExecute => {
             unreachable!("pipeline_execute is blocked before execute_step is called")
         }
@@ -668,7 +684,10 @@ enum AttemptOutcome {
     Failed { reason: String },
 }
 
-fn execute_dispatch_step(ctx: &mut ReportedStepExecutionContext<'_>) -> Result<(), RunError> {
+fn execute_dispatch_step(
+    ctx: &mut ReportedStepExecutionContext<'_>,
+    first_attempt: u32,
+) -> Result<(), RunError> {
     let paths = ctx.step.paths;
     let events_path = ctx.step.events_path;
     let run_id = ctx.step.run_id;
@@ -697,8 +716,9 @@ fn execute_dispatch_step(ctx: &mut ReportedStepExecutionContext<'_>) -> Result<(
 
     let mut last_failure_reason = String::new();
 
-    // Retry loop: attempt 1..=max_attempts
-    for attempt in 1..=step.max_attempts {
+    // Retry loop: max_attempts attempts, starting after any previous review round.
+    let last_attempt = first_attempt.saturating_add(step.max_attempts.saturating_sub(1));
+    for attempt in first_attempt..=last_attempt {
         let attempt_dir = paths.attempt_dir(phase_id, &step.id, attempt);
         std::fs::create_dir_all(&attempt_dir)?;
 
@@ -1008,8 +1028,9 @@ fn execute_synthesis_step(
     current_seq: &mut u64,
     phase_id: &str,
     step: &NormalizedStep,
+    first_attempt: u32,
 ) -> Result<(), RunError> {
-    let attempt: u32 = 1;
+    let attempt = first_attempt;
     let (attempt_dir, attempt_start) = emit_step_and_attempt_start(
         paths,
         events_path,
@@ -1059,14 +1080,17 @@ fn execute_synthesis_step(
 // Interactive step execution
 // ---------------------------------------------------------------------------
 
-fn execute_interactive_step(ctx: &mut ReportedStepExecutionContext<'_>) -> Result<(), RunError> {
+fn execute_interactive_step(
+    ctx: &mut ReportedStepExecutionContext<'_>,
+    first_attempt: u32,
+) -> Result<(), RunError> {
     let paths = ctx.step.paths;
     let events_path = ctx.step.events_path;
     let run_id = ctx.step.run_id;
     let phase_id = ctx.step.phase_id;
     let step = ctx.step.step_definition;
 
-    let attempt: u32 = 1;
+    let attempt = first_attempt;
     let (attempt_dir, attempt_start) = emit_step_and_attempt_start(
         paths,
         events_path,

--- a/core/capacitor-core/src/method_runner/resume.rs
+++ b/core/capacitor-core/src/method_runner/resume.rs
@@ -468,6 +468,8 @@ fn resume_phase_loop(
             .get(&phase_def.id)
             .map(|p| p.status)
             .unwrap_or(PhaseStatus::Pending);
+        let rerun_completed_steps =
+            blocked_phase_requires_fresh_round(&current_state, &phase_def.id);
 
         if phase_status == PhaseStatus::Completed || phase_status == PhaseStatus::Skipped {
             continue;
@@ -498,6 +500,7 @@ fn resume_phase_loop(
             dispatcher,
             interactive_io,
             reporter,
+            rerun_completed_steps,
         )?;
 
         if let Some(ref gate) = phase_def.gate {
@@ -546,6 +549,7 @@ fn resume_phase_steps(
     dispatcher: &dyn crate::method_runner::adapters::WorkerDispatcher,
     interactive_io: &dyn crate::method_runner::adapters::InteractiveIO,
     reporter: &dyn RunStatusReporter,
+    rerun_completed_steps: bool,
 ) -> Result<(), RunError> {
     for step_def in &phase_def.steps {
         let current_events = recover_events(events_path)?;
@@ -559,9 +563,15 @@ fn resume_phase_steps(
             .map(|s| s.status)
             .unwrap_or(StepStatus::Pending);
 
-        if step_status == StepStatus::Completed {
+        if step_status == StepStatus::Completed && !rerun_completed_steps {
             continue;
         }
+
+        let first_attempt = if rerun_completed_steps || step_status == StepStatus::Blocked {
+            next_step_attempt(&current_state, &phase_def.id, &step_def.id)
+        } else {
+            1
+        };
 
         let step_context = crate::method_runner::executor::StepExecutionContext {
             paths,
@@ -575,15 +585,40 @@ fn resume_phase_steps(
             interactive_io,
         };
 
-        if let Err(error) = crate::method_runner::executor::execute_step_public_with_reporter(
-            step_context,
-            reporter,
-        ) {
+        if let Err(error) =
+            crate::method_runner::executor::execute_step_public_with_reporter_from_attempt(
+                step_context,
+                reporter,
+                first_attempt,
+            )
+        {
             report_status_kind(reporter, RunStatusEventKind::Fail);
             return Err(error);
         }
     }
     Ok(())
+}
+
+fn blocked_phase_requires_fresh_round(state: &MethodRunState, phase_id: &str) -> bool {
+    state
+        .phases
+        .get(phase_id)
+        .filter(|phase| phase.status == PhaseStatus::Blocked)
+        .and_then(|phase| phase.gate_result.as_ref())
+        .is_some_and(|gate| gate.outcome != "approved")
+}
+
+fn next_step_attempt(state: &MethodRunState, phase_id: &str, step_id: &str) -> u32 {
+    state
+        .phases
+        .get(phase_id)
+        .and_then(|phase| phase.steps.get(step_id))
+        .map(|step| {
+            step.current_attempt
+                .max(step.attempts.keys().next_back().copied().unwrap_or(0))
+                .saturating_add(1)
+        })
+        .unwrap_or(1)
 }
 
 /// Evaluate a gate during resume and block the phase if not approved.

--- a/core/capacitor-core/src/method_runner/state.rs
+++ b/core/capacitor-core/src/method_runner/state.rs
@@ -153,6 +153,7 @@ impl StepStatus {
                 | (StepStatus::Running, StepStatus::Completed)
                 | (StepStatus::Running, StepStatus::Failed)
                 | (StepStatus::Running, StepStatus::Blocked)
+                | (StepStatus::Completed, StepStatus::Running)
                 | (StepStatus::Blocked, StepStatus::Running)
                 | (StepStatus::Blocked, StepStatus::Failed)
         );

--- a/core/capacitor-core/tests/method_runner/error_audit.rs
+++ b/core/capacitor-core/tests/method_runner/error_audit.rs
@@ -375,7 +375,7 @@ fn error_transition_phase_illegal() {
 
 #[test]
 fn error_transition_step_illegal() {
-    let result = StepStatus::Completed.transition_to(StepStatus::Running, "step-q");
+    let result = StepStatus::Failed.transition_to(StepStatus::Running, "step-q");
     let err = result.unwrap_err();
     let msg = err.to_string();
 

--- a/core/capacitor-core/tests/method_runner/interfaces.rs
+++ b/core/capacitor-core/tests/method_runner/interfaces.rs
@@ -701,13 +701,16 @@ fn interface_if6_step_legal_transitions() {
     assert!(StepStatus::Blocked
         .transition_to(StepStatus::Running, "s1")
         .is_ok());
+    assert!(StepStatus::Completed
+        .transition_to(StepStatus::Running, "s1")
+        .is_ok());
 }
 
 #[test]
 fn interface_if6_step_illegal_transitions() {
-    // Completed -> Running
+    // Completed -> Blocked
     assert!(StepStatus::Completed
-        .transition_to(StepStatus::Running, "s1")
+        .transition_to(StepStatus::Blocked, "s1")
         .is_err());
 
     // Pending -> Completed (skip)

--- a/core/capacitor-core/tests/method_runner/invariants.rs
+++ b/core/capacitor-core/tests/method_runner/invariants.rs
@@ -573,9 +573,9 @@ fn invariant_i8_legal_transitions_only() {
     assert!(err.to_string().contains("illegal transition"));
 
     // --- Step ---
-    // Illegal: Completed -> Running
+    // Illegal: Completed -> Blocked
     let err = StepStatus::Completed
-        .transition_to(StepStatus::Running, "test-step")
+        .transition_to(StepStatus::Blocked, "test-step")
         .unwrap_err();
     assert!(err.to_string().contains("illegal transition"));
 

--- a/core/capacitor-core/tests/method_runner/run_status_reporter.rs
+++ b/core/capacitor-core/tests/method_runner/run_status_reporter.rs
@@ -544,6 +544,168 @@ fn resume_blocked_gate_reports_resume_before_advancing_phase() {
 }
 
 #[test]
+fn resume_blocked_gate_reexecutes_phase_steps_before_checkpoint_reapproval() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let source = write_definition(&temp, &two_phase_gated_method_yaml());
+
+    let blocked_state = execute_run_with_reporter(
+        &source,
+        &FakePromptBuilder,
+        &FakeWorkerDispatcher,
+        &FakeInteractiveIO::new("rejected"),
+        &SpyRunStatusReporter::default(),
+    )
+    .expect("seed blocked gated run");
+    assert_eq!(blocked_state.status, RunStatus::Blocked);
+
+    let resumed_state = resume_run_with_reporter(
+        &source.execution_root,
+        &FakePromptBuilder,
+        &FakeWorkerDispatcher,
+        &FakeInteractiveIO::new("approved"),
+        &SpyRunStatusReporter::default(),
+    )
+    .expect("resume blocked run");
+    assert_eq!(resumed_state.status, RunStatus::Completed);
+    assert_eq!(
+        resumed_state
+            .phases
+            .get("phase-1")
+            .and_then(|phase| phase.steps.get("step-1"))
+            .map(|step| step.current_attempt),
+        Some(2),
+        "request-changes resume should create a new step attempt"
+    );
+
+    let paths = MethodRunPaths::new(&source.execution_root);
+    let method_events = recover_events(&paths.events_log()).expect("recover events");
+    let phase_blocked_index = method_events
+        .iter()
+        .position(|event| event.kind == MethodEventKind::PhaseBlocked)
+        .expect("expected phase blocked event");
+    let phase_restarted_index = method_events
+        .iter()
+        .enumerate()
+        .skip(phase_blocked_index + 1)
+        .find(|(_, event)| {
+            event.kind == MethodEventKind::PhaseStarted
+                && event.phase_id.as_deref() == Some("phase-1")
+        })
+        .map(|(index, _)| index)
+        .expect("expected blocked phase to restart");
+    let second_gate_index = method_events
+        .iter()
+        .enumerate()
+        .skip(phase_restarted_index + 1)
+        .find(|(_, event)| {
+            event.kind == MethodEventKind::GateEvaluated
+                && event.phase_id.as_deref() == Some("phase-1")
+        })
+        .map(|(index, _)| index)
+        .expect("expected gate to be re-evaluated after restart");
+
+    let worker_dispatch_attempts: Vec<u32> = method_events
+        .iter()
+        .filter(|event| {
+            event.kind == MethodEventKind::WorkerDispatched
+                && event.phase_id.as_deref() == Some("phase-1")
+                && event.step_id.as_deref() == Some("step-1")
+        })
+        .filter_map(|event| event.attempt)
+        .collect();
+    assert_eq!(
+        worker_dispatch_attempts,
+        vec![1, 2],
+        "request-changes resume should preserve the old attempt and run a fresh one"
+    );
+
+    let second_dispatch_index = method_events
+        .iter()
+        .enumerate()
+        .find(|(_, event)| {
+            event.kind == MethodEventKind::WorkerDispatched
+                && event.phase_id.as_deref() == Some("phase-1")
+                && event.step_id.as_deref() == Some("step-1")
+                && event.attempt == Some(2)
+        })
+        .map(|(index, _)| index)
+        .expect("expected second worker dispatch");
+    assert!(
+        phase_restarted_index < second_dispatch_index && second_dispatch_index < second_gate_index,
+        "phase restart must re-run worker before re-evaluating the gate"
+    );
+}
+
+#[test]
+fn request_changes_can_repeat_before_final_approval() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let source = write_definition(&temp, &two_phase_gated_method_yaml());
+
+    let first_blocked_state = execute_run_with_reporter(
+        &source,
+        &FakePromptBuilder,
+        &FakeWorkerDispatcher,
+        &FakeInteractiveIO::new("rejected"),
+        &SpyRunStatusReporter::default(),
+    )
+    .expect("seed first blocked gated run");
+    assert_eq!(first_blocked_state.status, RunStatus::Blocked);
+
+    let second_blocked_state = resume_run_with_reporter(
+        &source.execution_root,
+        &FakePromptBuilder,
+        &FakeWorkerDispatcher,
+        &FakeInteractiveIO::new("rejected"),
+        &SpyRunStatusReporter::default(),
+    )
+    .expect("second request-changes round should remain a controlled block");
+    assert_eq!(second_blocked_state.status, RunStatus::Blocked);
+
+    let completed_state = resume_run_with_reporter(
+        &source.execution_root,
+        &FakePromptBuilder,
+        &FakeWorkerDispatcher,
+        &FakeInteractiveIO::new("approved"),
+        &SpyRunStatusReporter::default(),
+    )
+    .expect("third round should approve and complete");
+    assert_eq!(completed_state.status, RunStatus::Completed);
+    assert_eq!(
+        completed_state
+            .phases
+            .get("phase-1")
+            .and_then(|phase| phase.steps.get("step-1"))
+            .map(|step| step.current_attempt),
+        Some(3),
+        "each request-changes round should preserve the previous attempt and create the next one"
+    );
+
+    let paths = MethodRunPaths::new(&source.execution_root);
+    let method_events = recover_events(&paths.events_log()).expect("recover events");
+    let worker_dispatch_attempts: Vec<u32> = method_events
+        .iter()
+        .filter(|event| {
+            event.kind == MethodEventKind::WorkerDispatched
+                && event.phase_id.as_deref() == Some("phase-1")
+                && event.step_id.as_deref() == Some("step-1")
+        })
+        .filter_map(|event| event.attempt)
+        .collect();
+    assert_eq!(worker_dispatch_attempts, vec![1, 2, 3]);
+    assert_eq!(
+        method_events
+            .iter()
+            .filter(|event| {
+                event.kind == MethodEventKind::PhaseBlocked
+                    && event.phase_id.as_deref() == Some("phase-1")
+            })
+            .count(),
+        2,
+        "two request-changes decisions should produce two blocked phase lifecycles"
+    );
+}
+
+#[test]
 fn resume_run_emits_immediate_recovered_phase_heartbeat() {
     let temp = tempfile::tempdir().expect("tempdir");
     let source = write_definition(&temp, &two_phase_method_yaml());

--- a/core/capacitor-core/tests/method_runner/state_machines.rs
+++ b/core/capacitor-core/tests/method_runner/state_machines.rs
@@ -587,7 +587,7 @@ fn phase_status_skipped_skipped_illegal() {
 }
 
 // =========================================================================
-// StepStatus — 5 variants, 25 total pairs, 6 legal
+// StepStatus — 5 variants, 25 total pairs, 7 legal
 // =========================================================================
 
 // --- Legal transitions ---
@@ -705,11 +705,10 @@ fn step_status_completed_pending_illegal() {
 }
 
 #[test]
-fn step_status_completed_running_illegal() {
-    assert_illegal(
+fn step_status_completed_running_legal() {
+    assert_legal(
         StepStatus::Completed.transition_to(StepStatus::Running, "s1"),
-        "Completed",
-        "Running",
+        StepStatus::Running,
     );
 }
 
@@ -1564,7 +1563,7 @@ fn sequence_worker_full_lifecycle() {
 fn transition_coverage_summary() {
     // RunStatus: 5 variants, 25 pairs, 6 legal, 19 illegal = 25 tested
     // PhaseStatus: 6 variants, 36 pairs, 7 legal, 29 illegal = 36 tested
-    // StepStatus: 5 variants, 25 pairs, 6 legal, 19 illegal = 25 tested
+    // StepStatus: 5 variants, 25 pairs, 7 legal, 18 illegal = 25 tested
     // AttemptStatus: 7 variants, 49 pairs, 8 legal, 41 illegal = 49 tested
     // WorkerStatus: 5 variants, 25 pairs, 4 legal, 21 illegal = 25 tested
 

--- a/docs/orchestrator/checkpoint-bridge.md
+++ b/docs/orchestrator/checkpoint-bridge.md
@@ -118,7 +118,7 @@ The key invariant: bridge-managed status is runtime truth (`active_checkpoint.de
 
 Accepted decisions move the decided checkpoint from `active_checkpoint` into the run's bounded `past_checkpoints` history, preserving the decision, timestamp, and review metadata for snapshot consumers. Approvals resume the run as `active`; request-changes decisions leave the run `paused` with no active checkpoint so the runtime remains non-terminal while the method runner records the blocked gate. The run kernel keeps the most recent 50 decided checkpoints per run.
 
-Request-changes is still a blocked-gate handoff, not a full multi-round worker retry loop. The retry loop remains a separate method-runner design step.
+Request-changes is a blocked-gate handoff plus an explicit method-runner retry round. When a blocked gate is resumed, the runner restarts the blocked phase, re-executes its completed steps using fresh attempt numbers, and then emits a new checkpoint. Repeated request-changes decisions repeat that loop while preserving prior attempts as history.
 
 A paused run with no active checkpoint cannot advance phases until it is resumed, preventing a request-changes decision from being bypassed by a stray `AdvancePhase` mutation.
 
@@ -198,6 +198,8 @@ This identity is what allows the relay to find the correct pending marker: the S
 | `rejected_gate_reports_pause_instead_of_fail` | A rejected human gate returns a blocked handoff, persists `RunBlocked`, and reports runtime `Pause` instead of terminal failure |
 | `resumed_rejected_gate_reports_pause_instead_of_fail` | The same controlled blocked handoff holds when the gate is reached through method-runner resume |
 | `resume_blocked_gate_reports_resume_before_advancing_phase` | Resume reports runtime `Resume` before `AdvancePhase` and restarts a blocked phase before completing it |
+| `resume_blocked_gate_reexecutes_phase_steps_before_checkpoint_reapproval` | A request-changes resume re-runs the blocked phase's completed work as a new attempt before re-evaluating the checkpoint |
+| `request_changes_can_repeat_before_final_approval` | Multiple request-changes rounds preserve old attempts and continue with attempts 1, 2, 3 before final approval |
 | `runtime_reporter_posts_mutate_commands_with_expected_mapping` | Reporter `Pause` and `Resume` events map to matching runtime mutations with status messages |
 
 ### `core/capacitor-core/src/reduce/run_reducer/tests/lifecycle.rs`


### PR DESCRIPTION
## Summary
- Re-run blocked gated phases on resume instead of only re-checking the stale checkpoint output.
- Preserve prior review-round attempts by continuing step attempt numbering across request-changes cycles.
- Update method-runner state-machine contracts and checkpoint bridge docs for completed-step rework rounds.

## Verification
- cargo test -p capacitor-core --test method_runner_contract
- cargo test -p capacitor-core --lib --tests
- cargo clippy -- -D warnings -W dead_code
- cargo test --workspace --lib --tests
- cargo build -p capacitor-core --release
- swift test --package-path apps/swift
- ./scripts/verify/verify.sh --layers 1
- git diff --check
- CLI smoke: reject -> reject -> approve produced state_status=completed, current_attempt=3, dispatch_attempts=1,2,3