### PR TITLE
Cover checkpoint timeline selector tie-breakers

### DIFF
--- a/apps/swift/Tests/CapacitorTests/AppStateRunTests.swift
+++ b/apps/swift/Tests/CapacitorTests/AppStateRunTests.swift
@@ -219,6 +219,206 @@ final class AppStateRunTests: XCTestCase {
         XCTAssertEqual(appState.checkpointTimelineRun(for: project)?.id, newerEventRun.id)
     }
 
+    func testCheckpointTimelineRunUsesUpdatedAtWhenCheckpointEventsMatch() async {
+        let projectPath = "/tmp/core-project"
+        let olderUpdatedRun = makeRun(
+            projectPath: projectPath,
+            runID: "run-older-updated",
+            status: "completed",
+            ideaId: nil,
+            createdAt: "2026-03-26T10:00:00Z",
+            updatedAt: "2026-03-26T10:10:00Z",
+            pastCheckpoints: [
+                makeCheckpoint(
+                    id: "checkpoint-same-event-a",
+                    createdAt: "2026-03-26T10:05:00Z",
+                    decidedAt: "2026-03-26T10:08:00Z",
+                    decisionAction: "approve",
+                ),
+            ],
+        )
+        let newerUpdatedRun = makeRun(
+            projectPath: projectPath,
+            runID: "run-newer-updated",
+            status: "completed",
+            ideaId: nil,
+            createdAt: "2026-03-26T10:00:00Z",
+            updatedAt: "2026-03-26T10:20:00Z",
+            pastCheckpoints: [
+                makeCheckpoint(
+                    id: "checkpoint-same-event-b",
+                    createdAt: "2026-03-26T10:06:00Z",
+                    decidedAt: "2026-03-26T10:08:00Z",
+                    decisionAction: "approve",
+                ),
+            ],
+        )
+
+        let selectedID = await checkpointTimelineRunID(
+            projectPath: projectPath,
+            runs: [olderUpdatedRun, newerUpdatedRun],
+            correlationId: "checkpoint-timeline-updated-tiebreaker",
+        )
+
+        XCTAssertEqual(selectedID, newerUpdatedRun.id)
+    }
+
+    func testCheckpointTimelineRunUsesCreatedAtWhenCheckpointEventAndUpdatedAtMatch() async {
+        let projectPath = "/tmp/core-project"
+        let olderCreatedRun = makeRun(
+            projectPath: projectPath,
+            runID: "run-older-created",
+            status: "completed",
+            ideaId: nil,
+            createdAt: "2026-03-26T09:50:00Z",
+            updatedAt: "2026-03-26T10:20:00Z",
+            pastCheckpoints: [
+                makeCheckpoint(
+                    id: "checkpoint-same-event-a",
+                    createdAt: "2026-03-26T10:05:00Z",
+                    decidedAt: "2026-03-26T10:08:00Z",
+                    decisionAction: "approve",
+                ),
+            ],
+        )
+        let newerCreatedRun = makeRun(
+            projectPath: projectPath,
+            runID: "run-newer-created",
+            status: "completed",
+            ideaId: nil,
+            createdAt: "2026-03-26T10:00:00Z",
+            updatedAt: "2026-03-26T10:20:00Z",
+            pastCheckpoints: [
+                makeCheckpoint(
+                    id: "checkpoint-same-event-b",
+                    createdAt: "2026-03-26T10:06:00Z",
+                    decidedAt: "2026-03-26T10:08:00Z",
+                    decisionAction: "approve",
+                ),
+            ],
+        )
+
+        let selectedID = await checkpointTimelineRunID(
+            projectPath: projectPath,
+            runs: [olderCreatedRun, newerCreatedRun],
+            correlationId: "checkpoint-timeline-created-tiebreaker",
+        )
+
+        XCTAssertEqual(selectedID, newerCreatedRun.id)
+    }
+
+    func testCheckpointTimelineRunUsesRunIDWhenTimestampTiebreakersMatch() async {
+        let projectPath = "/tmp/core-project"
+        let higherIDRun = makeRun(
+            projectPath: projectPath,
+            runID: "run-z",
+            status: "completed",
+            ideaId: nil,
+            createdAt: "2026-03-26T10:00:00Z",
+            updatedAt: "2026-03-26T10:20:00Z",
+            pastCheckpoints: [
+                makeCheckpoint(
+                    id: "checkpoint-z",
+                    createdAt: "2026-03-26T10:05:00Z",
+                    decidedAt: "2026-03-26T10:08:00Z",
+                    decisionAction: "approve",
+                ),
+            ],
+        )
+        let lowerIDRun = makeRun(
+            projectPath: projectPath,
+            runID: "run-a",
+            status: "completed",
+            ideaId: nil,
+            createdAt: "2026-03-26T10:00:00Z",
+            updatedAt: "2026-03-26T10:20:00Z",
+            pastCheckpoints: [
+                makeCheckpoint(
+                    id: "checkpoint-a",
+                    createdAt: "2026-03-26T10:06:00Z",
+                    decidedAt: "2026-03-26T10:08:00Z",
+                    decisionAction: "approve",
+                ),
+            ],
+        )
+
+        let selectedID = await checkpointTimelineRunID(
+            projectPath: projectPath,
+            runs: [higherIDRun, lowerIDRun],
+            correlationId: "checkpoint-timeline-run-id-tiebreaker",
+        )
+
+        XCTAssertEqual(selectedID, lowerIDRun.id)
+    }
+
+    func testCheckpointTimelineRunIncludesActiveCheckpointOnlyRun() async {
+        let projectPath = "/tmp/core-project"
+        let activeCheckpointRun = makeRun(
+            projectPath: projectPath,
+            runID: "run-active-checkpoint-only",
+            status: "paused",
+            ideaId: nil,
+            createdAt: "2026-03-26T10:00:00Z",
+            updatedAt: "2026-03-26T10:10:00Z",
+            activeCheckpoint: makeCheckpoint(
+                id: "checkpoint-active",
+                createdAt: "2026-03-26T10:09:00Z",
+            ),
+        )
+
+        let selectedID = await checkpointTimelineRunID(
+            projectPath: projectPath,
+            runs: [activeCheckpointRun],
+            correlationId: "checkpoint-timeline-active-only",
+        )
+
+        XCTAssertEqual(selectedID, activeCheckpointRun.id)
+    }
+
+    func testCheckpointTimelineRunTreatsInvalidCheckpointTimestampBehindValidTimestamp() async {
+        let projectPath = "/tmp/core-project"
+        let invalidEventRun = makeRun(
+            projectPath: projectPath,
+            runID: "run-invalid-event",
+            status: "completed",
+            ideaId: nil,
+            createdAt: "2026-03-26T10:00:00Z",
+            updatedAt: "2026-03-26T10:30:00Z",
+            pastCheckpoints: [
+                makeCheckpoint(
+                    id: "checkpoint-invalid-event",
+                    createdAt: "not-a-date",
+                    decidedAt: nil,
+                    decisionAction: "approve",
+                ),
+            ],
+        )
+        let validEventRun = makeRun(
+            projectPath: projectPath,
+            runID: "run-valid-event",
+            status: "completed",
+            ideaId: nil,
+            createdAt: "2026-03-26T09:00:00Z",
+            updatedAt: "2026-03-26T09:30:00Z",
+            pastCheckpoints: [
+                makeCheckpoint(
+                    id: "checkpoint-valid-event",
+                    createdAt: "2026-03-26T09:05:00Z",
+                    decidedAt: "2026-03-26T09:10:00Z",
+                    decisionAction: "approve",
+                ),
+            ],
+        )
+
+        let selectedID = await checkpointTimelineRunID(
+            projectPath: projectPath,
+            runs: [invalidEventRun, validEventRun],
+            correlationId: "checkpoint-timeline-invalid-event",
+        )
+
+        XCTAssertEqual(selectedID, validEventRun.id)
+    }
+
     private func makeProject(path: String) -> Project {
         Project(
             name: "Capacitor",
@@ -245,6 +445,27 @@ final class AppStateRunTests: XCTestCase {
             triage: "validated",
             related: nil,
         )
+    }
+
+    private func checkpointTimelineRunID(
+        projectPath: String,
+        runs: [RuntimeRunState],
+        correlationId: String,
+    ) async -> String? {
+        let appState = AppState()
+        appState.cancelRuntimeAutomationForTesting()
+        let project = makeProject(path: projectPath)
+        appState.projectState.projects = [project]
+        appState.setRuntimeSnapshotGenerationForTesting(1)
+
+        await appState.applyRuntimeSnapshotForTesting(
+            makeRuntimeSnapshot(projectPath: project.path, runs: runs),
+            refreshGeneration: 1,
+            correlationId: correlationId,
+            projects: [project],
+        )
+
+        return appState.checkpointTimelineRun(for: project)?.id
     }
 
     private func makeRuntimeSnapshot(


### PR DESCRIPTION
## Summary
- Add Swift coverage for checkpoint timeline run selector tie-breakers: event timestamp, updatedAt, createdAt, and run ID
- Add coverage for active-checkpoint-only runs appearing in Project Detail timeline selection
- Add coverage that invalid checkpoint event timestamps sort behind valid event timestamps

## Verification
- ./scripts/ci/swiftformat-lint.sh
- swift test --package-path apps/swift --filter AppStateRunTests
- git diff --check