### PR TITLE
Cover checkpoint timeline accessibility labels

### DIFF
--- a/apps/swift/Sources/Capacitor/Views/Projects/RunCheckpointTimelineSection.swift
+++ b/apps/swift/Sources/Capacitor/Views/Projects/RunCheckpointTimelineSection.swift
@@ -8,7 +8,9 @@ struct RunCheckpointTimelineSection: View {
             DetailSectionLabel(
                 title: "RUN CHECKPOINTS",
                 count: projection.entries.count,
-                countAccessibilityLabel: "\(projection.entries.count) checkpoints",
+                countAccessibilityLabel: RunCheckpointTimelineAccessibility.sectionCountLabel(
+                    entryCount: projection.entries.count,
+                ),
             )
 
             VStack(alignment: .leading, spacing: 6) {
@@ -82,7 +84,7 @@ private struct RunCheckpointTimelineRow: View {
                     }
                 }
 
-                Text(timestampText(for: entry))
+                Text(RunCheckpointTimelineAccessibility.timestampText(for: entry))
                     .font(AppTypography.monoCaption)
                     .foregroundColor(.white.opacity(0.34))
             }
@@ -99,7 +101,7 @@ private struct RunCheckpointTimelineRow: View {
                 ),
         )
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel)
+        .accessibilityLabel(RunCheckpointTimelineAccessibility.rowLabel(for: entry))
     }
 
     private var timelineRail: some View {
@@ -148,8 +150,14 @@ private struct RunCheckpointTimelineRow: View {
                 ),
         )
     }
+}
 
-    private var accessibilityLabel: String {
+enum RunCheckpointTimelineAccessibility {
+    static func sectionCountLabel(entryCount: Int) -> String {
+        "\(entryCount) \(entryCount == 1 ? "checkpoint" : "checkpoints")"
+    }
+
+    static func rowLabel(for entry: RunCheckpointTimelineProjection.Entry) -> String {
         var parts = [
             entry.title,
             entry.decisionState.label,
@@ -164,7 +172,7 @@ private struct RunCheckpointTimelineRow: View {
         return parts.joined(separator: ", ")
     }
 
-    private func timestampText(for entry: RunCheckpointTimelineProjection.Entry) -> String {
+    static func timestampText(for entry: RunCheckpointTimelineProjection.Entry) -> String {
         let timestamp = formattedTimestamp(entry.eventTimestamp)
         switch entry.timestampRole {
         case .created:
@@ -176,7 +184,7 @@ private struct RunCheckpointTimelineRow: View {
         }
     }
 
-    private func formattedTimestamp(_ timestamp: String) -> String {
+    private static func formattedTimestamp(_ timestamp: String) -> String {
         guard let date = parseISO8601Date(timestamp) else {
             return timestamp
         }

--- a/apps/swift/Tests/CapacitorTests/RunCheckpointTimelineSectionTests.swift
+++ b/apps/swift/Tests/CapacitorTests/RunCheckpointTimelineSectionTests.swift
@@ -1,0 +1,39 @@
+@testable import Capacitor
+import XCTest
+
+final class RunCheckpointTimelineSectionTests: XCTestCase {
+    func testCountAccessibilityLabelUsesSingularAndPluralCheckpointCopy() {
+        XCTAssertEqual(
+            RunCheckpointTimelineAccessibility.sectionCountLabel(entryCount: 1),
+            "1 checkpoint",
+        )
+        XCTAssertEqual(
+            RunCheckpointTimelineAccessibility.sectionCountLabel(entryCount: 2),
+            "2 checkpoints",
+        )
+    }
+
+    func testRowAccessibilityLabelIncludesDecisionPhaseRoundKindTimestampAndNote() {
+        let entry = RunCheckpointTimelineProjection.Entry(
+            id: "gate-review#history-3",
+            checkpointID: "gate-review",
+            source: .archived,
+            phaseID: "phase-001",
+            phaseName: "Execute",
+            phaseRoundNumber: 2,
+            kindLabel: "Implementation",
+            title: "Review checkpoint",
+            summary: "Summary is visible but not repeated in the combined label.",
+            decisionState: .changesRequested,
+            decisionNote: "Needs another pass",
+            createdAt: "2026-03-26T10:00:00Z",
+            decidedAt: "not-a-date",
+            timestampRole: .decided,
+        )
+
+        XCTAssertEqual(
+            RunCheckpointTimelineAccessibility.rowLabel(for: entry),
+            "Review checkpoint, Changes requested, Execute, round 2, Implementation, Decided not-a-date, note: Needs another pass",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Extract checkpoint timeline accessibility label composition into a small pure Swift helper.
- Fix the Project Detail timeline count label so `1 checkpoint` is singular.
- Add focused tests for timeline count labels and combined row labels, including decision, phase, round, kind, timestamp, and note text.

## Verification

- `swift test --package-path apps/swift --filter RunCheckpointTimelineSectionTests`
- `swift test --package-path apps/swift --filter RunCheckpointTimeline`
- `./scripts/ci/swiftformat-lint.sh`
- `git diff --check`
- `./scripts/dev/restart-alpha-stable.sh`
- pre-commit hook: passed