### PR TITLE
Cover checkpoint bridge marker retention

### DIFF
--- a/core/capacitor-core/src/method_runner/checkpoint_bridge.rs
+++ b/core/capacitor-core/src/method_runner/checkpoint_bridge.rs
@@ -56,6 +56,12 @@ impl BridgeInteractiveIO {
         }
     }
 
+    #[doc(hidden)]
+    pub fn with_poll_timeout(mut self, poll_timeout: Duration) -> Self {
+        self.poll_timeout = poll_timeout;
+        self
+    }
+
     fn manifest_path(&self, manifest_path: &Path) -> PathBuf {
         if manifest_path.is_absolute() {
             manifest_path.to_path_buf()
@@ -234,6 +240,8 @@ impl InteractiveIO for BridgeInteractiveIO {
                             gate_id, self.poll_timeout
                         );
                         *self.current_gate_id.borrow_mut() = None;
+                        // Keep the pending marker: runtime truth may still expose the
+                        // active checkpoint, and a later retry needs the relay handoff.
                         return InteractiveResponse {
                             body: "rejected".to_string(),
                         };
@@ -243,6 +251,8 @@ impl InteractiveIO for BridgeInteractiveIO {
                 Err(error) => {
                     eprintln!("warning: {}", error);
                     *self.current_gate_id.borrow_mut() = None;
+                    // Drop only the bad decision artifact. The pending marker still
+                    // belongs to the runtime-visible checkpoint retry path.
                     self.delete_decision_file(&gate_id);
                     return InteractiveResponse {
                         body: "rejected".to_string(),

--- a/core/capacitor-core/tests/method_runner/checkpoint_bridge.rs
+++ b/core/capacitor-core/tests/method_runner/checkpoint_bridge.rs
@@ -1380,3 +1380,147 @@ fn t15_bridge_falls_back_to_prompt_when_server_unreachable() {
         "bridge should fall back to standard prompt when server is unreachable"
     );
 }
+
+#[test]
+fn t16_bridge_timeout_keeps_pending_marker_for_runtime_retry() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home_dir = temp.path().join("home");
+    let project_path = temp.path().join("project");
+    let manifest_path = project_path.join("artifacts/checkpoint-manifest.json");
+    std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+        .expect("create manifest parent");
+    std::fs::write(&manifest_path, "{}").expect("write manifest");
+
+    let server = StubMutationServer::spawn("bridge-token");
+    let bridge = make_bridge(
+        "run-timeout",
+        project_path,
+        home_dir.clone(),
+        server.endpoint("bridge-token"),
+    )
+    .with_poll_timeout(Duration::ZERO);
+
+    let mut context = bridge_context(&manifest_path);
+    context.gate_id = "gate-timeout".to_string();
+    context.prompt_message = "Gate 'gate-timeout': Do you approve?".to_string();
+
+    bridge.emit_gate_checkpoint(&context);
+    server.finish();
+
+    let marker = pending_path(&home_dir, "run-timeout", "gate-timeout");
+    assert!(
+        marker.exists(),
+        "pending marker should exist before the decision poll times out"
+    );
+
+    let response =
+        capacitor_core::method_runner::adapters::InteractiveIO::capture_response(&bridge);
+    assert_eq!(response.body, "rejected");
+    assert!(
+        marker.exists(),
+        "pending marker should remain so the runtime-visible checkpoint can be retried"
+    );
+}
+
+#[test]
+fn t17_bridge_invalid_decision_keeps_pending_marker_and_removes_bad_file() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home_dir = temp.path().join("home");
+    let project_path = temp.path().join("project");
+    let manifest_path = project_path.join("artifacts/checkpoint-manifest.json");
+    std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+        .expect("create manifest parent");
+    std::fs::write(&manifest_path, "{}").expect("write manifest");
+
+    let server = StubMutationServer::spawn("bridge-token");
+    let bridge = make_bridge(
+        "run-invalid-decision",
+        project_path,
+        home_dir.clone(),
+        server.endpoint("bridge-token"),
+    );
+
+    let mut context = bridge_context(&manifest_path);
+    context.gate_id = "gate-invalid-decision".to_string();
+    context.prompt_message = "Gate 'gate-invalid-decision': Do you approve?".to_string();
+
+    bridge.emit_gate_checkpoint(&context);
+    server.finish();
+
+    let marker = pending_path(&home_dir, "run-invalid-decision", "gate-invalid-decision");
+    let decision = decision_path(&home_dir, "run-invalid-decision", "gate-invalid-decision");
+    std::fs::write(&decision, "{not valid json").expect("write malformed decision");
+
+    let response =
+        capacitor_core::method_runner::adapters::InteractiveIO::capture_response(&bridge);
+    assert_eq!(response.body, "rejected");
+    assert!(
+        marker.exists(),
+        "pending marker should remain after an invalid decision so runtime retry is possible"
+    );
+    assert!(
+        !decision.exists(),
+        "invalid decision file should be removed so the next bridge attempt is not poisoned"
+    );
+}
+
+#[test]
+fn t18_bridge_unsupported_decision_version_keeps_pending_marker_and_removes_bad_file() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home_dir = temp.path().join("home");
+    let project_path = temp.path().join("project");
+    let manifest_path = project_path.join("artifacts/checkpoint-manifest.json");
+    std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+        .expect("create manifest parent");
+    std::fs::write(&manifest_path, "{}").expect("write manifest");
+
+    let server = StubMutationServer::spawn("bridge-token");
+    let bridge = make_bridge(
+        "run-unsupported-decision",
+        project_path,
+        home_dir.clone(),
+        server.endpoint("bridge-token"),
+    );
+
+    let mut context = bridge_context(&manifest_path);
+    context.gate_id = "gate-unsupported-decision".to_string();
+    context.prompt_message = "Gate 'gate-unsupported-decision': Do you approve?".to_string();
+
+    bridge.emit_gate_checkpoint(&context);
+    server.finish();
+
+    let marker = pending_path(
+        &home_dir,
+        "run-unsupported-decision",
+        "gate-unsupported-decision",
+    );
+    let decision = decision_path(
+        &home_dir,
+        "run-unsupported-decision",
+        "gate-unsupported-decision",
+    );
+    write_json_atomic(
+        &decision,
+        &CheckpointBridgeDecision {
+            version: 99,
+            run_id: "run-unsupported-decision".to_string(),
+            checkpoint_id: "gate-unsupported-decision".to_string(),
+            action: "approve".to_string(),
+            note: Some("Future protocol".to_string()),
+            decided_at: "2026-03-24T12:20:00Z".to_string(),
+        },
+    )
+    .expect("write unsupported decision");
+
+    let response =
+        capacitor_core::method_runner::adapters::InteractiveIO::capture_response(&bridge);
+    assert_eq!(response.body, "rejected");
+    assert!(
+        marker.exists(),
+        "pending marker should remain after a version error so runtime retry is possible"
+    );
+    assert!(
+        !decision.exists(),
+        "unsupported decision file should be removed so the next bridge attempt is not poisoned"
+    );
+}

--- a/docs/orchestrator/checkpoint-bridge.md
+++ b/docs/orchestrator/checkpoint-bridge.md
@@ -98,8 +98,8 @@ Any failure in `emit_gate_checkpoint` cleans up state and falls back to the inte
 - **Pending marker write failure**: Falls back to prompt. `checkpoint_bridge.rs:261-270`
 - **Runtime mutation rejected** (`ok: false`): Deletes the pending marker and falls back to prompt. The `current_gate_id` is never set, so `capture_response()` delegates to the fallback IO. `checkpoint_bridge.rs:272-281`
 - **Runtime mutation HTTP error**: Same cleanup and fallback path. `checkpoint_bridge.rs:177-183`
-- **Decision file parse error** during poll: Returns "rejected" and deletes the corrupt file. `checkpoint_bridge.rs:225-232`
-- **Decision file version mismatch**: Returns error, which triggers "rejected" response. `checkpoint_bridge.rs:145-150`
+- **Decision file parse error** during poll: Returns "rejected", deletes the corrupt decision file, and keeps the pending marker so the runtime-visible checkpoint can still be retried through the relay. `checkpoint_bridge.rs:149-155`, `checkpoint_bridge.rs:251-258`
+- **Decision file version mismatch**: Returns error, which triggers the same "rejected" response, bad-decision cleanup, and pending-marker retention. `checkpoint_bridge.rs:156-160`, `checkpoint_bridge.rs:251-258`
 - **Decision file committed but pending marker cleanup missed**: The bridge consumes the decision, deletes the stale pending marker, then deletes the decision file. This recovers from a hud-hook relay crash after commit but before cleanup.
 
 The key invariant: `current_gate_id` is only set to `Some(gate_id)` after all of pending marker write + runtime mutation succeed (`checkpoint_bridge.rs:283`). If either step fails, `capture_response()` falls through to the fallback IO.
@@ -131,7 +131,7 @@ Swift review-window targeting still requires `activeCheckpoint`, but project-car
 
 ### Timeout Behavior
 
-`DECISION_POLL_TIMEOUT` is 3600 seconds (1 hour). Defined at `checkpoint_bridge.rs:28`. After timeout, `capture_response` returns `InteractiveResponse { body: "rejected" }` so the method runner records a blocked gate rather than waiting forever. The poll interval is 500ms (`checkpoint_bridge.rs:223`).
+`DECISION_POLL_TIMEOUT` is 3600 seconds (1 hour). Defined at `checkpoint_bridge.rs:28`. After timeout, `capture_response` returns `InteractiveResponse { body: "rejected" }` so the method runner records a blocked gate rather than waiting forever. The bridge clears its in-memory armed gate but deliberately keeps the pending marker, because runtime truth may still expose the active checkpoint and a later retry must be able to commit through the relay. The poll interval is 500ms (`checkpoint_bridge.rs:249`).
 
 ## CLI Integration
 
@@ -196,6 +196,9 @@ This identity is what allows the relay to find the correct pending marker: the S
 | `t14_bridge_isolates_same_gate_id_across_concurrent_runs` (line 1190) | Two runs with the same gate_id use separate bridge directories and do not cross-contaminate |
 | `t15_bridge_falls_back_to_prompt_when_mutation_rejected` (line 1359) | Runtime rejection triggers fallback to interactive prompt (fail-closed) |
 | `t15_bridge_falls_back_to_prompt_when_server_unreachable` (line 1399) | Unreachable server triggers fallback to interactive prompt (fail-closed) |
+| `t16_bridge_timeout_keeps_pending_marker_for_runtime_retry` | Timeout returns "rejected" without deleting the pending marker needed by a runtime retry |
+| `t17_bridge_invalid_decision_keeps_pending_marker_and_removes_bad_file` | Malformed decision files are removed while pending markers remain retryable |
+| `t18_bridge_unsupported_decision_version_keeps_pending_marker_and_removes_bad_file` | Unsupported decision versions are removed while pending markers remain retryable |
 
 ### `core/capacitor-core/tests/method_runner/run_status_reporter.rs`
 


### PR DESCRIPTION
## Summary
- Add checkpoint bridge contracts for timeout, malformed decision, and unsupported decision-version paths.
- Keep pending markers intact for runtime-visible retry paths while removing poisoned decision artifacts.
- Document the marker-retention behavior in the canonical checkpoint bridge spec.

## Validation
- `cargo fmt`
- `cargo test -p capacitor-core --test method_runner_contract checkpoint_bridge`
- `cargo +1.95.0 test -p capacitor-core --test method_runner_contract checkpoint_bridge`
- `cargo clippy -p capacitor-core --lib -- -D warnings`
- `./scripts/verify/verify.sh --bootstrap`
- `./scripts/verify/verify.sh --layers 1`
- `git diff --check`
- pre-commit hook: broader Rust test sweep passed during commit

## Notes
- `cargo clippy -p capacitor-core --test method_runner_contract -- -D warnings` is still blocked by pre-existing unrelated warnings in `adversarial.rs` and `constraints.rs`; this PR leaves those untouched.