### PR TITLE
fix: don't trap user in connect-projects onboarding on a failed project load

### DIFF
--- a/apps/swift/Sources/Capacitor/ContentView.swift
+++ b/apps/swift/Sources/Capacitor/ContentView.swift
@@ -54,7 +54,11 @@ struct ContentView: View {
                     .zIndex(100)
                 }
 
-                if !uiState.isLoading, appState.projectState.projects.isEmpty, !isDragHovered, !uiState.isFileDragOverCard {
+                if ProjectsEmptyStatePolicy.shouldShowConnectOnboarding(
+                    isLoading: uiState.isLoading,
+                    projectsAreEmpty: appState.projectState.projects.isEmpty,
+                    loadPhase: uiState.projectsLoadPhase,
+                ), !isDragHovered, !uiState.isFileDragOverCard {
                     EmptyStateBorderGlow()
                         .transition(.opacity)
                 }

--- a/apps/swift/Sources/Capacitor/Models/AppState+Lifecycle.swift
+++ b/apps/swift/Sources/Capacitor/Models/AppState+Lifecycle.swift
@@ -152,6 +152,7 @@ extension AppState {
         do {
             uiState.dashboard = try engine.loadDashboard()
             projectState.projects = uiState.dashboard?.projects ?? []
+            uiState.projectsLoadPhase = .loaded
             if projectState.projects.isEmpty, projectState.suggestedProjects.isEmpty {
                 refreshSuggestedProjects()
             } else if !projectState.projects.isEmpty, !projectState.suggestedProjects.isEmpty {
@@ -168,6 +169,8 @@ extension AppState {
                 uiState.isLoading = false
             }
         } catch {
+            DebugLog.write("AppState.loadDashboard failed error=\(error.localizedDescription)")
+            uiState.projectsLoadPhase = .failed
             uiState.error = error.localizedDescription
             if showLoadingState {
                 uiState.isLoading = false

--- a/apps/swift/Sources/Capacitor/Models/UIState.swift
+++ b/apps/swift/Sources/Capacitor/Models/UIState.swift
@@ -7,6 +7,12 @@ enum LayoutMode: String, CaseIterable {
     case dock
 }
 
+enum ProjectsLoadPhase: Equatable {
+    case initial
+    case loaded
+    case failed
+}
+
 enum ProjectView: Equatable {
     case list
     case detail(Project)
@@ -70,6 +76,7 @@ final class UIState {
 
     var dashboard: DashboardData?
     var isLoading = true
+    var projectsLoadPhase: ProjectsLoadPhase = .initial
     var error: String?
     var toast: ToastMessage?
     var pendingDragDropTip = false

--- a/apps/swift/Sources/Capacitor/Views/Footer/FooterView.swift
+++ b/apps/swift/Sources/Capacitor/Views/Footer/FooterView.swift
@@ -24,7 +24,11 @@ struct FooterView: View {
         if !appState.projectState.selectedSuggestedPaths.isEmpty {
             return .connectCTA
         }
-        if !appState.uiState.isLoading, appState.projectState.projects.isEmpty {
+        if ProjectsEmptyStatePolicy.shouldShowConnectOnboarding(
+            isLoading: appState.uiState.isLoading,
+            projectsAreEmpty: appState.projectState.projects.isEmpty,
+            loadPhase: appState.uiState.projectsLoadPhase,
+        ) {
             return .browse
         }
         return .normal

--- a/apps/swift/Sources/Capacitor/Views/Projects/ProjectsEmptyStatePolicy.swift
+++ b/apps/swift/Sources/Capacitor/Views/Projects/ProjectsEmptyStatePolicy.swift
@@ -1,0 +1,20 @@
+/// Distinguishes "genuinely zero connected projects" (show first-run onboarding)
+/// from "a project load failed" (show a recoverable error), so a transient
+/// loadDashboard() failure never masquerades as first-run onboarding.
+enum ProjectsEmptyStatePolicy {
+    static func shouldShowConnectOnboarding(
+        isLoading: Bool,
+        projectsAreEmpty: Bool,
+        loadPhase: ProjectsLoadPhase,
+    ) -> Bool {
+        !isLoading && projectsAreEmpty && loadPhase == .loaded
+    }
+
+    static func shouldShowLoadFailure(
+        isLoading: Bool,
+        projectsAreEmpty: Bool,
+        loadPhase: ProjectsLoadPhase,
+    ) -> Bool {
+        !isLoading && projectsAreEmpty && loadPhase == .failed
+    }
+}

--- a/apps/swift/Sources/Capacitor/Views/Projects/ProjectsView.swift
+++ b/apps/swift/Sources/Capacitor/Views/Projects/ProjectsView.swift
@@ -96,11 +96,21 @@ struct ProjectsView: View {
             scrollbarMaskWidth: maskScrollbarWidth,
         )
         let scrollbarInset = floatingMode ? WindowCornerRadius.value(floatingMode: floatingMode) : 0
+        let shouldShowConnectOnboarding = ProjectsEmptyStatePolicy.shouldShowConnectOnboarding(
+            isLoading: appState.uiState.isLoading,
+            projectsAreEmpty: appState.projectState.projects.isEmpty,
+            loadPhase: appState.uiState.projectsLoadPhase,
+        )
+        let shouldShowLoadFailure = ProjectsEmptyStatePolicy.shouldShowLoadFailure(
+            isLoading: appState.uiState.isLoading,
+            projectsAreEmpty: appState.projectState.projects.isEmpty,
+            loadPhase: appState.uiState.projectsLoadPhase,
+        )
 
         // Empty state: uses ScrollView with gradient mask for visual
         // consistency with the project list. Content flows naturally
         // (no .frame(maxHeight: .infinity) to avoid layout oscillation).
-        if !appState.uiState.isLoading, appState.projectState.projects.isEmpty {
+        if shouldShowConnectOnboarding || shouldShowLoadFailure {
             ScrollView {
                 VStack(spacing: 0) {
                     ProjectListDiagnosticsSection()
@@ -119,8 +129,13 @@ struct ProjectsView: View {
                         .padding(.horizontal, listHorizontalPadding)
                         .padding(.bottom, 4)
                     }
-                    EmptyProjectsView()
-                        .frame(maxWidth: .infinity)
+                    if shouldShowLoadFailure {
+                        ProjectsLoadFailureView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        EmptyProjectsView()
+                            .frame(maxWidth: .infinity)
+                    }
                 }
                 .padding(.top, contentTopPadding)
                 .padding(.bottom, contentBottomPadding)
@@ -1187,6 +1202,77 @@ struct EmptyProjectsView: View {
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.1)) {
                 hoveredPath = hovering ? suggestion.path : nil
+            }
+        }
+    }
+}
+
+struct ProjectsLoadFailureView: View {
+    @Environment(AppState.self) var appState: AppState
+    @Environment(\.floatingMode) private var floatingMode
+    @Environment(\.prefersReducedMotion) private var reduceMotion
+
+    @State private var appeared = false
+    @State private var retryHovered = false
+
+    var body: some View {
+        VStack(spacing: OnboardingStyle.headerToContentSpacing) {
+            VStack(spacing: OnboardingStyle.logoToHeadingSpacing) {
+                BrandLogomark(size: OnboardingStyle.logomarkSize)
+
+                Text("Couldn't load your projects")
+                    .font(AppTypography.onboardingHeading)
+                    .foregroundColor(OnboardingStyle.headingColor)
+                    .multilineTextAlignment(.center)
+
+                Text("Something went wrong reading your project list.")
+                    .font(AppTypography.onboardingSubtitle)
+                    .foregroundColor(OnboardingStyle.subtitleColor)
+                    .multilineTextAlignment(.center)
+            }
+
+            Button(action: { appState.loadDashboard() }) {
+                Text("Retry")
+                    .font(AppTypography.labelMedium.weight(.semibold))
+                    .foregroundColor(.white.opacity(retryHovered ? 0.9 : 0.65))
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 8)
+                    .background(
+                        Capsule()
+                            .fill(Color.white.opacity(retryHovered ? 0.12 : 0.06)),
+                    )
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(Color.white.opacity(retryHovered ? 0.24 : 0.12), lineWidth: 0.5),
+                    )
+            }
+            .buttonStyle(.plain)
+            .scaleEffect(retryHovered && !reduceMotion ? 1.02 : 1.0)
+            .animation(reduceMotion ? AppMotion.reducedMotionFallback : .easeOut(duration: 0.15), value: retryHovered)
+            .onHover { hovering in
+                retryHovered = hovering
+            }
+        }
+        .padding(.top, 16)
+        .frame(maxWidth: .infinity)
+        .opacity(appeared || reduceMotion ? 1 : 0)
+        .offset(y: appeared || reduceMotion ? 0 : 8)
+        .background {
+            if floatingMode {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .windowDraggable()
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Project list failed to load")
+        .onAppear {
+            if !reduceMotion {
+                withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
+                    appeared = true
+                }
+            } else {
+                appeared = true
             }
         }
     }

--- a/apps/swift/Tests/CapacitorTests/ProjectsEmptyStatePolicyTests.swift
+++ b/apps/swift/Tests/CapacitorTests/ProjectsEmptyStatePolicyTests.swift
@@ -1,0 +1,69 @@
+@testable import Capacitor
+import XCTest
+
+final class ProjectsEmptyStatePolicyTests: XCTestCase {
+    func testConnectOnboardingOnlyShowsAfterLoadedEmptyProjects() {
+        XCTAssertFalse(
+            ProjectsEmptyStatePolicy.shouldShowConnectOnboarding(
+                isLoading: false,
+                projectsAreEmpty: true,
+                loadPhase: .failed,
+            ),
+        )
+        XCTAssertTrue(
+            ProjectsEmptyStatePolicy.shouldShowConnectOnboarding(
+                isLoading: false,
+                projectsAreEmpty: true,
+                loadPhase: .loaded,
+            ),
+        )
+        XCTAssertFalse(
+            ProjectsEmptyStatePolicy.shouldShowConnectOnboarding(
+                isLoading: true,
+                projectsAreEmpty: true,
+                loadPhase: .loaded,
+            ),
+        )
+        XCTAssertFalse(
+            ProjectsEmptyStatePolicy.shouldShowConnectOnboarding(
+                isLoading: false,
+                projectsAreEmpty: false,
+                loadPhase: .loaded,
+            ),
+        )
+    }
+
+    func testLoadFailureShowsOnlyAfterFailedEmptyProjects() {
+        XCTAssertTrue(
+            ProjectsEmptyStatePolicy.shouldShowLoadFailure(
+                isLoading: false,
+                projectsAreEmpty: true,
+                loadPhase: .failed,
+            ),
+        )
+    }
+
+    func testConnectOnboardingAndLoadFailureAreMutuallyExclusive() {
+        for isLoading in [false, true] {
+            for projectsAreEmpty in [false, true] {
+                for loadPhase in [ProjectsLoadPhase.initial, .loaded, .failed] {
+                    let showOnboarding = ProjectsEmptyStatePolicy.shouldShowConnectOnboarding(
+                        isLoading: isLoading,
+                        projectsAreEmpty: projectsAreEmpty,
+                        loadPhase: loadPhase,
+                    )
+                    let showFailure = ProjectsEmptyStatePolicy.shouldShowLoadFailure(
+                        isLoading: isLoading,
+                        projectsAreEmpty: projectsAreEmpty,
+                        loadPhase: loadPhase,
+                    )
+
+                    XCTAssertFalse(
+                        showOnboarding && showFailure,
+                        "onboarding and failure both true for isLoading=\(isLoading), projectsAreEmpty=\(projectsAreEmpty), loadPhase=\(loadPhase)",
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

After the Hickey-teardown refactor, the app could get **stuck on the "Connect your projects" onboarding** even when projects were connected: you could check projects in the suggested list, but Connect was a silent no-op and there was no way into the app.

### Root cause
`projectState.projects` is written in **exactly one place** — `AppState.loadDashboard()` (`AppState+Lifecycle.swift`). Its `catch` block set `uiState.error`, **logged nothing**, and left the list empty. The UI treats an empty project list as "first-run → show the Connect-your-projects onboarding" in three places (`ProjectsView`, `ContentView`, `FooterView`).

So when `engine.loadDashboard()` **threw** (a transient UniFFI decode failure — e.g. a binding/dylib skew after the `workspace_id` FFI shape change), the failure was silently indistinguishable from "you have zero projects," trapping the user in onboarding. Because `getSuggestedProjects()` uses a different, still-decodable struct, the user's already-pinned projects surfaced as "suggestions" — and clicking Connect called `addProject()` on already-pinned paths (no-op), so nothing happened.

The data and Rust were never at fault: calling `CoreRuntime::new().load_dashboard()` directly against real storage returns all pinned projects correctly.

## Fix

Distinguish **"project load failed"** from **"genuinely zero connected projects"** so a transient failure can never masquerade as first-run onboarding:

- Add `UIState.projectsLoadPhase` (`initial` / `loaded` / `failed`).
- `loadDashboard()` now **logs** failures and sets `.failed` (retaining the last-good list instead of blanking it); success sets `.loaded`.
- New pure, tested `ProjectsEmptyStatePolicy`:
  - connect-onboarding shows **only** on `!isLoading && empty && .loaded`
  - a load failure shows a **"Couldn't load your projects — Retry"** view instead
- Route `ProjectsView` / `ContentView` / `FooterView` through the policy.

The empty-projects onboarding itself was never broken — it was masked by the silent load failure. (The immediate trigger in the reporter's environment was a stale debug build with skewed UniFFI bindings; a clean rebuild restores project loading. This PR is the durable guardrail so a future skew degrades gracefully with a Retry instead of an inescapable onboarding.)

## Testing

- New `ProjectsEmptyStatePolicyTests` (XCTest) — the key assertion `shouldShowConnectOnboarding(isLoading: false, projectsAreEmpty: true, loadPhase: .failed) == false` is exactly what the old inline logic got wrong (red→green baked into the assertion). 3/3 pass.
- `swift build` clean; SwiftFormat 0.61.1 reports 0/7 files need formatting.
- Pre-commit hooks pass locally (Rust+Swift format, formal verification layer 1, full Rust suite).

## Scope

Swift-only. No Rust, UniFFI bindings, or build-script changes.